### PR TITLE
Allow cacert value to propagate to libcurl

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1972,12 +1972,13 @@ VALUE ruby_curl_easy_setup( ruby_curl_easy *rbce ) {
     }
   }
   if (!rb_easy_nil("cacert")) {
-#ifdef HAVE_CURL_CONFIG_CA
-    curl_easy_setopt(curl, CURLOPT_CAINFO, CURL_CONFIG_CA);
-#else
-    curl_easy_setopt(curl, CURLOPT_CAINFO, "/usr/local/share/curl/curl-ca-bundle.crt");
-#endif
+    curl_easy_setopt(curl, CURLOPT_CAINFO, rb_easy_get_str("cacert"));
   }
+#ifdef HAVE_CURL_CONFIG_CA
+  else {
+    curl_easy_setopt(curl, CURLOPT_CAINFO, CURL_CONFIG_CA);
+  }
+#endif
 
 #ifdef CURL_VERSION_SSL
   if (rbce->ssl_version > 0) {


### PR DESCRIPTION
In the current version of Curb (0.7.15), a user can set the "cacert" variable on an Curl::Easy instance (i.e., a user can set the value and successfully print it back out using the getter/setter methods).  However, the value does not seem to propagate down to the libcurl CURLOPT_CAINFO option.  Instead, Curb always uses either the CURL_CONFIG_CA option or a hardcoded "/usr/local/share/curl/curl-ca-bundle.crt" path if "cacert" is set to a value.  This is highly confusing and more importantly less secure if a user does not want to use a large, default bundle of CA certs.

I have fixed this bug by properly using the "cacert" value if specified.  If "cacert" is not set, the code will default to the the CURLOPT_CAINFO value if it is defined.  I have removed the other default of "/usr/local/share/curl/curl-ca-bundle.crt" as this shouldn't be set automatically (could have adverse side effects).

Also, is there a plan to support the "verify_callback" provided by the OpenSSL "SSL_CTX_set_verify" method (similar to Net::HTTP)?  Without the verify callback, this makes cert checking very difficult as you can only react after the connection has gone through (using the Curb "ssl_verify_result" value).  This means that Curb will tell you that the source was unverified, but you cannot stop Curb from sending the data as the OpenSSL default "verify_callback" always continues on any cert problem.  This makes Curb almost unusable from a security standpoint unless there is something I am missing.
