### PR TITLE
Support CURLOPT_IPRESOLVE with Curl::Easy#resolve_mode.

### DIFF
--- a/ext/curb_easy.h
+++ b/ext/curb_easy.h
@@ -56,6 +56,7 @@ typedef struct {
   long ssl_version;
   long use_ssl;
   long ftp_filemethod;
+  unsigned short resolve_mode;
 
   /* bool flags */
   char proxy_tunnel;

--- a/ext/curb_macros.h
+++ b/ext/curb_macros.h
@@ -8,6 +8,7 @@
 #ifndef __CURB_MACROS_H
 #define __CURB_MACROS_H
 
+#define rb_easy_sym(sym) ID2SYM(rb_intern(sym))
 #define rb_easy_hkey(key) ID2SYM(rb_intern(key))
 #define rb_easy_set(key,val) rb_hash_aset(rbce->opts, rb_easy_hkey(key) , val)
 #define rb_easy_get(key) rb_hash_aref(rbce->opts, rb_easy_hkey(key))

--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -507,6 +507,17 @@ class TestCurbCurlEasy < Test::Unit::TestCase
     assert c.ignore_content_length?
   end
 
+  def test_resolve_mode
+    c = Curl::Easy.new
+    assert c.resolve_mode == :auto
+    c.resolve_mode = :ipv4
+    assert c.resolve_mode == :ipv4
+    c.resolve_mode = :ipv6
+    assert c.resolve_mode == :ipv6
+
+    assert_raises(ArgumentError) { c.resolve_mode = :bad }
+  end
+
   def test_enable_cookies
     c = Curl::Easy.new
     assert !c.enable_cookies?


### PR DESCRIPTION
I wanted to force a Curl::Easy instance to resolve DNS names to IPv4 addresses, even when there are both IPv6 and IPv4 addresses available, but couldn't find a hook to the libcurl option that does this (CURLOPT_IPRESOLVE). So I made one. The "resolve_mode" is a symbol attribute with the following three options:

```
:auto => CURL_IPRESOLVE_WHATEVER
:ipv4 => CURL_IPRESOLVE_V4,
:ipv6 => CURL_IPRESOLVE_V6
```

Sorry if this code is a little bit clumsy: I'm new to working with Ruby extensions in C.
