### PR TITLE
Fix a few VALUE handling bugs

### DIFF
--- a/ext/curb.c
+++ b/ext/curb.c
@@ -6,6 +6,7 @@
  */
 
 #include "curb.h"
+#include "curb_upload.h"
 
 VALUE mCurl;
 
@@ -959,4 +960,5 @@ void Init_curb_core() {
   init_curb_easy();
   init_curb_postfield();
   init_curb_multi();
+  init_curb_upload();
 }

--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1760,7 +1760,10 @@ static VALUE ruby_curl_easy_on_debug_set(int argc, VALUE *argv, VALUE self) {
 /***********************************************
  * This is an rb_iterate callback used to set up http headers.
  */
-static VALUE cb_each_http_header(VALUE header, struct curl_slist **list) {
+static VALUE cb_each_http_header(VALUE header, VALUE wrap) {
+  struct curl_slist **list;
+  Data_Get_Struct(wrap, struct curl_slist *, list);
+
   VALUE header_str = Qnil;
 
   //rb_p(header);
@@ -1789,7 +1792,10 @@ static VALUE cb_each_http_header(VALUE header, struct curl_slist **list) {
 /***********************************************
  * This is an rb_iterate callback used to set up ftp commands.
  */
-static VALUE cb_each_ftp_command(VALUE ftp_command, struct curl_slist **list) {
+static VALUE cb_each_ftp_command(VALUE ftp_command, VALUE wrap) {
+  struct curl_slist **list;
+  Data_Get_Struct(wrap, struct curl_slist *, list);
+
   VALUE ftp_command_string = rb_obj_as_string(ftp_command);
   *list = curl_slist_append(*list, StringValuePtr(ftp_command));
 
@@ -2069,7 +2075,8 @@ VALUE ruby_curl_easy_setup( ruby_curl_easy *rbce ) {
 
   if (!rb_easy_nil("headers")) {
     if (rb_easy_type_check("headers", T_ARRAY) || rb_easy_type_check("headers", T_HASH)) {
-      rb_iterate(rb_each, rb_easy_get("headers"), cb_each_http_header, (VALUE)hdrs);
+      VALUE wrap = Data_Wrap_Struct(rb_cObject, 0, 0, hdrs);
+      rb_iterate(rb_each, rb_easy_get("headers"), cb_each_http_header, wrap);
     } else {
       VALUE headers_str = rb_obj_as_string(rb_easy_get("headers"));
       *hdrs = curl_slist_append(*hdrs, StringValuePtr(headers_str));
@@ -2083,7 +2090,8 @@ VALUE ruby_curl_easy_setup( ruby_curl_easy *rbce ) {
   /* Setup FTP commands if necessary */
   if (!rb_easy_nil("ftp_commands")) {
     if (rb_easy_type_check("ftp_commands", T_ARRAY)) {
-      rb_iterate(rb_each, rb_easy_get("ftp_commands"), cb_each_ftp_command, (VALUE)cmds);
+      VALUE wrap = Data_Wrap_Struct(rb_cObject, 0, 0, cmds);
+      rb_iterate(rb_each, rb_easy_get("ftp_commands"), cb_each_ftp_command, wrap);
     }
 
     if (*cmds) {
@@ -3047,7 +3055,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
  * Iniital access to libcurl curl_easy_getinfo, remember getinfo doesn't return the same values as setopt
  */
 static VALUE ruby_curl_easy_get_opt(VALUE self, VALUE opt) {
-  
+  return Qnil;
 }
 
 /*

--- a/ext/curb_multi.c
+++ b/ext/curb_multi.c
@@ -38,13 +38,9 @@ static void rb_curl_multi_remove(ruby_curl_multi *rbcm, VALUE easy);
 static void rb_curl_multi_read_info(VALUE self, CURLM *mptr);
 static void rb_curl_multi_run(VALUE self, CURLM *multi_handle, int *still_running);
 
-static void rb_curl_multi_mark_all_easy(VALUE key, VALUE rbeasy, ruby_curl_multi *rbcm) {
-  rb_gc_mark(rbeasy);
-}
-
 static void curl_multi_mark(ruby_curl_multi *rbcm) {
   rb_gc_mark(rbcm->requests);
-  rb_hash_foreach( rbcm->requests, (int (*)())rb_curl_multi_mark_all_easy, (VALUE)rbcm );
+  rb_gc_mark(rbcm->requests);
 }
 
 static void curl_multi_flush_easy(VALUE key, VALUE easy, ruby_curl_multi *rbcm) {


### PR DESCRIPTION
There are 2 bugs fixed in this commit.

1) rb_hash_foreach can't be used in a mark function since it might run ruby code, but it's not necessary since you can just mark the hash itself for the same effect.

2) You can't cast random pointers to VALUE. MRI happens to allow it because it doesn't check the values, but it's really invalid. So I've just wrapped them so they can be passed through via rb_iterate properly.
