### PR TITLE
Unable to get SSL peer verification to work

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1962,9 +1962,9 @@ VALUE ruby_curl_easy_setup( ruby_curl_easy *rbce ) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, rbce->ssl_verify_host);
 
   if ((rbce->use_netrc != Qnil) && (rbce->use_netrc != Qfalse)) {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, CURL_NETRC_OPTIONAL);
+    curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_OPTIONAL);
   } else {
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, CURL_NETRC_IGNORED);
+    curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_IGNORED);
   }
 
   curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, rbce->unrestricted_auth);


### PR DESCRIPTION
I was unable to get Curl::Easy to (intentionally) fail on a self-signed certificate with this code:

```
Curl::Easy.http_get("https://localhost/") do |curb|
  curb.ssl_verify_peer = true
  curb.ssl_verify_host = 2
end
```

The HTTPS request would always work, even if the certificate is not signed by a trusted authority.

I traced the issue back to a few copy-paste mistakes in ext/curb_easy.c. The attached pull request should be pretty self-explanatory.

Though I have to mention, there is one debatable change I made:

In the pull request you will see that I changed the default value of 'ssl_verify_host' from 1 to 2. I changed it to 2 because this is the default value that cURL uses for this setting. I think for the sake of consistency, Curl::Easy should be in sync with cURLs defaults.

This change is just a suggestion. I can see that there is a counter-argument about keeping backwards compatibility with older curb versions which speaks against this change. It's your decision. I isolated the change of the setting into its own commit, feel free to skip this one when pulling.
