### PR TITLE
Support CURLOPT_RESUME_FROM in Curl::Easy

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3146,7 +3146,10 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     VALUE cookiejar = val;
     CURB_OBJECT_HSETTER(ruby_curl_easy, cookiejar);
     } break;
-
+  case CURLOPT_RESUME_FROM: {
+    curl_easy_setopt(rbce->curl, CURLOPT_RESUME_FROM, FIX2LONG(val));
+    break;
+   }
   default:
     break;
   }


### PR DESCRIPTION
This small patch adds CURLOPT_RESUME_FROM support, so one can resume downloads using `set :resume_from, [BYTES]`.  Consequently, it fixes issue #99.
