### PR TITLE
Support CURLOPT_FAILONERROR

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3148,8 +3148,10 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     } break;
   case CURLOPT_RESUME_FROM: {
     curl_easy_setopt(rbce->curl, CURLOPT_RESUME_FROM, FIX2LONG(val));
-    break;
-   }
+    } break;
+  case CURLOPT_FAILONERROR: {
+    curl_easy_setopt(rbce->curl, CURLOPT_FAILONERROR, FIX2LONG(val));
+    } break;
   default:
     break;
   }


### PR DESCRIPTION
This commit:
- Fixes a minor formatting mistake from my last commit request
- Adds CURLOPT_FAILONERROR to the `set` function.   The default is _0_, which means that curb.body, or the body parameter in the on_body callback, will include the text returned by the server (such as a 404 page).  But when `set :failonerror, 1` is used, nothing will be in the body.
