### PR TITLE
Fix "Super simple API" raising "undefined method" exceptions

### DIFF
--- a/lib/curb.rb
+++ b/lib/curb.rb
@@ -1,3 +1,4 @@
 require 'curb_core'
+require 'curl'
 require 'curl/easy'
 require 'curl/multi'

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -9,7 +9,7 @@ $LIBDIR = File.join($TOPDIR, 'lib')
 $:.unshift($LIBDIR)
 $:.unshift($EXTDIR)
 
-require 'curl'
+require 'curb'
 require 'test/unit'
 require 'fileutils'
 


### PR DESCRIPTION
`require 'curb'` should `require 'curl'`.

Tests are incorrectly passing because the test helper was doing `require 'curl'`.
