### PR TITLE
Error when installing with -Werror=format-security

### DIFF
--- a/ext/curb_errors.c
+++ b/ext/curb_errors.c
@@ -459,7 +459,7 @@ VALUE rb_curl_easy_error(CURLcode code) {
 /* rb_raise an approriate exception for the supplied CURLcode */
 void raise_curl_easy_error_exception(CURLcode code) {
   VALUE obj = rb_curl_easy_error(code);
-  rb_raise(rb_ary_entry(obj,0), RSTRING_PTR(rb_ary_entry(obj,1)));
+  rb_raise(rb_ary_entry(obj,0), "%s", RSTRING_PTR(rb_ary_entry(obj,1)));
 }
 VALUE rb_curl_multi_error(CURLMcode code) {
   VALUE exclz;
@@ -509,7 +509,7 @@ VALUE rb_curl_multi_error(CURLMcode code) {
 }
 void raise_curl_multi_error_exception(CURLMcode code) {
   VALUE obj = rb_curl_multi_error(code);
-  rb_raise(rb_ary_entry(obj,0), RSTRING_PTR(rb_ary_entry(obj,1)));
+  rb_raise(rb_ary_entry(obj,0), "%s", RSTRING_PTR(rb_ary_entry(obj,1)));
 }
 
 void init_curb_errors() {


### PR DESCRIPTION
This patch fixes 2 errors when curb is compiled with format-security flags.

format-security is enabled by extconf.rb when curb is installed with the stock wheezy/sid ruby
