### PR TITLE
Fix postalize parameter escaping

### DIFF
--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -51,7 +51,7 @@ module Curl
   end
 
   def self.postalize(params={})
-    params.map {|k,v| "#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}" }.join('&')
+    URI.encode_www_form(params)
   end
 
 end


### PR DESCRIPTION
I found that the way post parameter encoding was handled in `Curl.postalize` was flawed. In particular, it does not correctly escape ampersand in parameters. I thought using `URI.encode_www_form` instead.
