### PR TITLE
Fix tests with IPv6 enabled

### DIFF
--- a/tests/bug_crash_on_debug.rb
+++ b/tests/bug_crash_on_debug.rb
@@ -19,7 +19,7 @@ class BugCrashOnDebug < Test::Unit::TestCase
       srv.start
     end
     puts 'b'
-    c = Curl::Easy.new('http://localhost:9999/test')
+    c = Curl::Easy.new('http://127.0.0.1:9999/test')
     c.on_debug do|x|
       puts x.inspect
       raise "error" # this will get swallowed

--- a/tests/bug_crash_on_progress.rb
+++ b/tests/bug_crash_on_progress.rb
@@ -16,7 +16,7 @@ class BugCrashOnDebug < Test::Unit::TestCase
       srv.start
     end
 
-    c = Curl::Easy.new('http://localhost:9999/test')
+    c = Curl::Easy.new('http://127.0.0.1:9999/test')
     c.on_progress do|x|
       raise "error"
     end

--- a/tests/bug_curb_easy_blocks_ruby_threads.rb
+++ b/tests/bug_curb_easy_blocks_ruby_threads.rb
@@ -21,7 +21,7 @@ class BugTestInstancePostDiffersFromClassPost < Test::Unit::TestCase
 
     5.times do |i|
       t = Thread.new do
-        c = Curl::Easy.perform('http://localhost:9999/test')
+        c = Curl::Easy.perform('http://127.0.0.1:9999/test')
         c.header_str
       end
       threads << t
@@ -37,7 +37,7 @@ class BugTestInstancePostDiffersFromClassPost < Test::Unit::TestCase
     timer = Time.now
     single_responses = []
     5.times do |i|
-      c = Curl::Easy.perform('http://localhost:9999/test')
+      c = Curl::Easy.perform('http://127.0.0.1:9999/test')
       single_responses << c.header_str
     end
     

--- a/tests/tc_curl_download.rb
+++ b/tests/tc_curl_download.rb
@@ -8,7 +8,7 @@ class TestCurbCurlDownload < Test::Unit::TestCase
   end
   
   def test_download_url_to_file_via_string
-    dl_url = "http://localhost:9129/ext/curb_easy.c"
+    dl_url = "http://127.0.0.1:9129/ext/curb_easy.c"
     dl_path = File.join(Dir::tmpdir, "dl_url_test.file")
 
     curb = Curl::Easy.download(dl_url, dl_path)
@@ -19,7 +19,7 @@ class TestCurbCurlDownload < Test::Unit::TestCase
   end
 
   def test_download_url_to_file_via_file_io
-    dl_url = "http://localhost:9129/ext/curb_easy.c"
+    dl_url = "http://127.0.0.1:9129/ext/curb_easy.c"
     dl_path = File.join(Dir::tmpdir, "dl_url_test.file")
     io = File.open(dl_path, 'wb')
 
@@ -32,7 +32,7 @@ class TestCurbCurlDownload < Test::Unit::TestCase
   end
 
   def test_download_url_to_file_via_io
-    dl_url = "http://localhost:9129/ext/curb_easy.c"
+    dl_url = "http://127.0.0.1:9129/ext/curb_easy.c"
     dl_path = File.join(Dir::tmpdir, "dl_url_test.file")
     reader, writer = IO.pipe
 
@@ -62,7 +62,7 @@ class TestCurbCurlDownload < Test::Unit::TestCase
   end
 
   def test_download_bad_url_gives_404
-    dl_url = "http://localhost:9129/this_file_does_not_exist.html"
+    dl_url = "http://127.0.0.1:9129/this_file_does_not_exist.html"
     dl_path = File.join(Dir::tmpdir, "dl_url_test.file")
 
     curb = Curl::Easy.download(dl_url, dl_path)


### PR DESCRIPTION
The socket is open to '127.0.0.1' and not 'localhost'; on systems
where IPv6 is enabled and configured, 'localhost' is actually
resolving to ::1 first.
