### PR TITLE
Fix for issue 117, exception raised when process is signaled

### DIFF
--- a/ext/curb_multi.c
+++ b/ext/curb_multi.c
@@ -589,8 +589,10 @@ VALUE ruby_curl_multi_perform(int argc, VALUE *argv, VALUE self) {
 
       switch(rc) {
       case -1:
-        rb_raise(rb_eRuntimeError, "select(): %s", strerror(errno));
-        break;
+        if(errno != EINTR) {
+          rb_raise(rb_eRuntimeError, "select(): %s", strerror(errno));
+          break;
+        }
       case 0: /* timeout */
       default: /* action */
         rb_curl_multi_run( self, rbcm->handle, &(rbcm->running) );

--- a/tests/signals.rb
+++ b/tests/signals.rb
@@ -1,0 +1,33 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
+
+# This test suite requires the timeout server to be running
+# See tests/timeout.rb for more info about the timeout server
+class TestCurbSignals < Test::Unit::TestCase
+
+  # Testcase for https://github.com/taf2/curb/issues/117
+  def test_continue_after_signal
+    trap("SIGUSR1") { }
+
+    curl = Curl::Easy.new(wait_url(2))
+    pid = $$
+    Thread.new do
+      sleep 1
+      Process.kill("SIGUSR1", pid)
+    end
+    assert_equal true, curl.http_get
+  end
+
+  private
+  
+  def wait_url(time)
+    "#{server_base}/wait/#{time}"
+  end
+  
+  def serve_url(chunk_size, time, count)
+    "#{server_base}/serve/#{chunk_size}/every/#{time}/for/#{count}"
+  end
+  
+  def server_base
+    'http://127.0.0.1:9128'
+  end
+end


### PR DESCRIPTION
We ran into issue 117 recently when migrating a Rails application to Unicorn. Our Rails application communicates with back-end services using Curb. The situation we ran into is the following:
- When shutting down Unicorn (in order to deploy a new version of our app, for example), Unicorn sends a SIGQUIT signal to all its workers to tell them to shutdown gracefully.
- If any of those worker is waiting on a select() call inside curb, the signal interrupts the system call, and curb raises a Ruby exception, that interrupts the request.

This is caused by the kernel interrupting the select() calls when processes running curb are signaled. The select() calls returns -1, with an errno equal to EINTR. The correct behaviour in that case should be to retry the select() call.

The commit in this PR changes this behaviour, by ignoring errors if and only if the errno is set to EINTR. In all other cases, the error still raises an exception.
