### PR TITLE
Fix gemspec

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib','ext']
   s.rubyforge_project = 'curb'
   s.summary = %q{Ruby libcurl bindings}
-  s.test_files = ["tests/alltests.rb", "tests/bug_crash_on_debug.rb", "tests/bug_crash_on_progress.rb", "tests/bug_curb_easy_blocks_ruby_threads.rb", "tests/bug_curb_easy_post_with_string_no_content_length_header.rb", "tests/bug_instance_post_differs_from_class_post.rb", "tests/bug_issue102.rb", "tests/bug_multi_segfault.rb", "tests/bug_postfields_crash.rb", "tests/bug_postfields_crash2.rb", "tests/bug_require_last_or_segfault.rb", "tests/bugtests.rb", "tests/foo.rb", "tests/helper.rb", "tests/mem_check.rb", "tests/require_last_or_segfault_script.rb", "tests/signals.rb", "tests/tc_curl.rb", "tests/tc_curl_download.rb", "tests/tc_curl_easy.rb", "tests/tc_curl_easy_setopt.rb", "tests/tc_curl_multi.rb", "tests/tc_curl_postfield.rb", "tests/timeout.rb", "tests/timeout_server.rb", "tests/unittests.rb"]
+  s.test_files = ["tests/alltests.rb", "tests/bug_crash_on_debug.rb", "tests/bug_crash_on_progress.rb", "tests/bug_curb_easy_blocks_ruby_threads.rb", "tests/bug_curb_easy_post_with_string_no_content_length_header.rb", "tests/bug_instance_post_differs_from_class_post.rb", "tests/bug_multi_segfault.rb", "tests/bug_postfields_crash.rb", "tests/bug_postfields_crash2.rb", "tests/bug_require_last_or_segfault.rb", "tests/bugtests.rb", "tests/helper.rb", "tests/mem_check.rb", "tests/require_last_or_segfault_script.rb", "tests/signals.rb", "tests/tc_curl.rb", "tests/tc_curl_download.rb", "tests/tc_curl_easy.rb", "tests/tc_curl_easy_setopt.rb", "tests/tc_curl_multi.rb", "tests/tc_curl_postfield.rb", "tests/timeout.rb", "tests/timeout_server.rb", "tests/unittests.rb"]
   
     s.extensions << 'ext/extconf.rb'
   


### PR DESCRIPTION
Hi,

I was having the following error while bundling:

```
curb at /Users/leo/.rbenv/versions/1.9.3-p327/lib/ruby/gems/1.9.1/bundler/gems/curb-0d11a1ff0212 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
If you need to use this package without installing it from a gem repository, please contact todd.fisher@gmail.com and ask them to modify their .gemspec so it can work with `gem build`.
The validation message from Rubygems was:
  ["tests/bug_issue102.rb", "tests/foo.rb"] are not files
```

So I deleted these two (missing) files from the gemspec. I am unsure it was the right way to solve this, but it seems to work now.
