### PR TITLE
Shortcut method has post_body(put_dat) reusing bug.

### DIFF
--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -8,6 +8,7 @@ module Curl
   
   def self.http(verb, url, post_body=nil, put_data=nil, &block)
     handle = Thread.current[:curb_curl] ||= Curl::Easy.new
+    handle.reset
     handle.url = url
     handle.post_body = post_body if post_body
     handle.put_data = put_data if put_data


### PR DESCRIPTION
Curl.get sends last POST request's post_body again. (put_data also)

I wrote simple sinatra application and called GET, POST, and then GET again. 

``` ruby
require 'sinatra'

get '/' do
  "Params: #{params.inspect}\nRequest body: #{request.body.string}"
end

post '/' do
  "Params: #{params.inspect}\nRequest body: #{request.body.string}"
end
```

[11] test »  puts Curl.get('http://localhost:4567?a=1&b=2').body_str
Params: {"a"=>"1", "b"=>"2"}
Request body:
[12] test »  puts Curl.post('http://localhost:4567', {:a => 3, :b =>4}).body_str
Params: {"a"=>"3", "b"=>"4"}
Request body: a=3&b=4
=> nil
[13] test »  puts Curl.get('http://localhost:4567?a=1&b=2').body_str
Params: **{"a"=>"3", "b"=>"4"}** **#should be {"a"=>"1", "b"=>"2"}**
Request body: a=3&b=4 *\* #should be empty **
=> nil
