### PR TITLE
Add suport for the new error 'CURLM_ADDED_ALREADY' introduced at curl 7.33

### DIFF
--- a/ext/curb_errors.c
+++ b/ext/curb_errors.c
@@ -118,7 +118,9 @@ VALUE mCurlErrBadEasyHandle;
 VALUE mCurlErrOutOfMemory;
 VALUE mCurlErrInternalError;
 VALUE mCurlErrBadSocket;
+#if HAVE_CURLM_ADDED_ALREADY
 VALUE mCurlErrAddedAlready;
+#endif
 VALUE mCurlErrUnknownOption;
 
 /* binding errors */
@@ -494,9 +496,11 @@ VALUE rb_curl_multi_error(CURLMcode code) {
       exclz = mCurlErrUnknownOption;
       break;
 #endif
+#if HAVE_CURLM_ADDED_ALREADY
     case CURLM_ADDED_ALREADY: /* 7 */
       exclz = mCurlErrAddedAlready;
       break;
+#endif
     default:
       exclz = eCurlErrError;
       exmsg = "Unknown error result from libcurl";
@@ -629,7 +633,9 @@ void init_curb_errors() {
   mCurlErrOutOfMemory        = rb_define_class_under(mCurlErr, "MultiOutOfMemory", eCurlErrError);
   mCurlErrInternalError      = rb_define_class_under(mCurlErr, "MultiInternalError", eCurlErrError);
   mCurlErrBadSocket          = rb_define_class_under(mCurlErr, "MultiBadSocket", eCurlErrError);
+#if HAVE_CURLM_ADDED_ALREADY
   mCurlErrAddedAlready       = rb_define_class_under(mCurlErr, "MultiAddedAlready", eCurlErrError);
+#endif
   mCurlErrUnknownOption      = rb_define_class_under(mCurlErr, "MultiUnknownOption", eCurlErrError);
 
   eCurlErrLDAPInvalidURL = rb_define_class_under(mCurlErr, "InvalidLDAPURLError", eCurlErrLDAPError);

--- a/ext/curb_errors.h
+++ b/ext/curb_errors.h
@@ -116,7 +116,9 @@ extern VALUE mCurlErrOutOfMemory;
 extern VALUE mCurlErrInternalError;
 extern VALUE mCurlErrBadSocket;
 extern VALUE mCurlErrUnknownOption;
+#if HAVE_CURLM_ADDED_ALREADY
 extern VALUE mCurlErrAddedAlready;
+#endif
 
 /* binding errors */
 extern VALUE eCurlErrInvalidPostField;

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -357,6 +357,8 @@ have_constant "curlopt_gssapi_delegation"
 have_constant "curlgssapi_delegation_policy_flag"
 have_constant "curlgssapi_delegation_flag"
 
+have_constant "CURLM_ADDED_ALREADY"
+
 if try_compile('int main() { return 0; }','-Wall')
   $CFLAGS << ' -Wall'
 end

--- a/tests/tc_curl_multi.rb
+++ b/tests/tc_curl_multi.rb
@@ -466,7 +466,7 @@ class TestCurbCurlMulti < Test::Unit::TestCase
     m.add(c)
     m.add(c)
   rescue => e
-    assert_equal Curl::Err::MultiAddedAlready, e.class
+    assert Curl::Err::MultiBadEasyHandle == e.class || Curl::Err::MultiAddedAlready == e.class
   end
 
   def test_multi_default_timeout


### PR DESCRIPTION
This fix the test 'test_reusing_handle' failing due to a new error introduced in the new curl 7.33.0 version.
