### PR TITLE
Use 0.0.0.0 rather than user specific IP address.

### DIFF
--- a/tests/bug_issue102.rb
+++ b/tests/bug_issue102.rb
@@ -4,7 +4,7 @@ class BugIssue102 < Test::Unit::TestCase
 
   def test_interface
     test = "https://api.twitter.com/1/users/show.json?screen_name=TwitterAPI&include_entities=true"
-    ip = "192.168.1.61"
+    ip = "0.0.0.0"
 
     c = Curl::Easy.new do |curl|
       curl.url = test


### PR DESCRIPTION
Test fails with 192.168.1.61. Replaced with 0.0.0.0.

Reference to original issue: https://github.com/taf2/curb/issues/102
