### PR TITLE
Use correctly cased HTTP verb for DELETE requests

### DIFF
--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -83,7 +83,7 @@ module Curl
     #   easy.perform
     #
     def delete=(onoff)
-      set :customrequest, onoff ? 'delete' : nil
+      set :customrequest, onoff ? 'DELETE' : nil
       onoff
     end
     # 


### PR DESCRIPTION
Currently, we set the HTTP method to `"delete"` in `Curl::Easy#delete=`, but it should actually be set to `"DELETE"` in order for it to work consistently across all conforming HTTP servers, as HTTP methods are case sensitive. See [RFC 2616 section 5.1.1](http://www.w3.org/Protocols/rfc2616/rfc2616-sec5.html#sec5.1.1).
