### PR TITLE
[FIX] Curl#urlalize - CGI.escape for param values

### DIFF
--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -2,6 +2,7 @@ require 'curb_core'
 require 'curl/easy'
 require 'curl/multi'
 require 'uri'
+require 'cgi'
 
 # expose shortcut methods
 module Curl
@@ -46,7 +47,7 @@ module Curl
   end
 
   def self.urlalize(url, params={})
-    query_str = params.map {|k,v| "#{URI.escape(k.to_s)}=#{URI.escape(v.to_s)}" }.join('&')
+    query_str = params.map {|k,v| "#{URI.escape(k.to_s)}=#{CGI.escape(v.to_s)}" }.join('&')
     if url.match(/\?/)
       "#{url}&#{query_str}"
     elsif query_str.size > 0


### PR DESCRIPTION
- URI.escape does not escapes characters '&' and '?'. When in parameter
  value is one of this characters, things goes seriously wrong.
  For example:
  
  ``` ruby
  urlalize('http://foo.bar', a: 'b&c?d=1')
  => "http://foo.bar?a=b&c?d=1"
  ```
  
  As you can see, this is definitely wrong url.
  But it is even worse. When I escape my value with CGI.escape,
  URI.escape in urlalize escapes all '%'. So again, wrong :(
  Example: 
  
  ``` ruby
  urlalize('http://foo.bar', a: CGI.escape('b&c'))
  => 'http://foo.bar?a=b%2526c'
  ```
  
  I don't see any way how to send '&' or '?' to server. In first case,
  parameter value with '&' or '?' is separated into more values, in
  second case, for '&' will be send '%2526' which server represents as
  '%26' instead of '&'.
- solution: use CGI.escape for values instead of URI.escape
