### PR TITLE
Status method now returns last status from response headers

### DIFF
--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -13,7 +13,7 @@ module Curl
     def status
       # Matches the last HTTP Status - following the HTTP protocol specification 'Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF'
       statuses = self.header_str.scan(/HTTP\/\d\.\d\s(\d+\s.+)\r\n/).map{ |match|  match[0] }
-      statuses.last.trim
+      statuses.last.strip
     end
 
     #


### PR DESCRIPTION
Fixes #132 by parsing the response headers and returning the last status found.
