### PR TITLE
Curl::Easy: Use alloc/initialize-pattern for easier subclassing.

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -262,23 +262,10 @@ static void ruby_curl_easy_zero(ruby_curl_easy *rbce) {
   rbce->callback_active = 0;
 }
 
-/*
- * call-seq:
- *   Curl::Easy.new                                   => #&lt;Curl::Easy...&gt;
- *   Curl::Easy.new(url = nil)                        => #&lt;Curl::Easy...&gt;
- *   Curl::Easy.new(url = nil) { |self| ... }         => #&lt;Curl::Easy...&gt;
- *
- * Create a new Curl::Easy instance, optionally supplying the URL.
- * The block form allows further configuration to be supplied before
- * the instance is returned.
- */
-static VALUE ruby_curl_easy_new(int argc, VALUE *argv, VALUE klass) {
+static VALUE ruby_curl_easy_alloc(VALUE klass) {
   CURLcode ecode;
-  VALUE url, blk;
   VALUE new_curl;
   ruby_curl_easy *rbce;
-
-  rb_scan_args(argc, argv, "01&", &url, &blk);
 
   rbce = ALLOC(ruby_curl_easy);
 
@@ -295,19 +282,39 @@ static VALUE ruby_curl_easy_new(int argc, VALUE *argv, VALUE klass) {
 
   ruby_curl_easy_zero(rbce);
 
-  rb_easy_set("url", url);
-
   /* set the new_curl pointer to the curl handle */
   ecode = curl_easy_setopt(rbce->curl, CURLOPT_PRIVATE, (void*)new_curl);
   if (ecode != CURLE_OK) {
     raise_curl_easy_error_exception(ecode);
   }
 
+  return new_curl;
+}
+
+/*
+ * call-seq:
+ *   Curl::Easy.new                                   => #&lt;Curl::Easy...&gt;
+ *   Curl::Easy.new(url = nil)                        => #&lt;Curl::Easy...&gt;
+ *   Curl::Easy.new(url = nil) { |self| ... }         => #&lt;Curl::Easy...&gt;
+ *
+ * Create a new Curl::Easy instance, optionally supplying the URL.
+ * The block form allows further configuration to be supplied before
+ * the instance is returned.
+ */
+static VALUE ruby_curl_easy_initialize(int argc, VALUE *argv, VALUE self) {
+  VALUE url, blk;
+  ruby_curl_easy *rbce;
+
+  rb_scan_args(argc, argv, "01&", &url, &blk);
+  Data_Get_Struct(self, ruby_curl_easy, rbce);
+
+  rb_easy_set("url", url);
+
   if (blk != Qnil) {
-    rb_funcall(blk, idCall, 1, new_curl);
+    rb_funcall(blk, idCall, 1, self);
   }
 
-  return new_curl;
+  return self;
 }
 
 /*
@@ -3264,9 +3271,9 @@ void init_curb_easy() {
   rb_global_variable(&rbstrAmp);
 
   cCurlEasy = rb_define_class_under(mCurl, "Easy", rb_cObject);
+  rb_define_alloc_func(cCurlEasy, ruby_curl_easy_alloc);
 
   /* Class methods */
-  rb_define_singleton_method(cCurlEasy, "new", ruby_curl_easy_new, -1);
   rb_define_singleton_method(cCurlEasy, "error", ruby_curl_easy_error_message, 1);
 
   /* Attributes for config next perform */
@@ -3424,6 +3431,7 @@ void init_curb_easy() {
   /* Runtime support */
   rb_define_method(cCurlEasy, "clone", ruby_curl_easy_clone, 0);
   rb_define_alias(cCurlEasy, "dup", "clone");
+  rb_define_method(cCurlEasy, "initialize", ruby_curl_easy_initialize, -1);
   rb_define_method(cCurlEasy, "inspect", ruby_curl_easy_inspect, 0);
 
   rb_define_method(cCurlEasy, "multi", ruby_curl_easy_multi_get, 0);

--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -88,8 +88,16 @@ class TestCurbCurlEasy < Test::Unit::TestCase
     assert_match(/^# DO NOT REMOVE THIS COMMENT/, c.body_str)
   end
 
-  # test invalid use of new
+  class Bar < Curl::Easy; def initialize(url, bar); super(url); @bar = bar; end; end
   def test_new_06
+    # can use Curl::Easy as a base class; calls #initialize
+    c = Bar.new($TEST_URL, 42)
+    assert_equal $TEST_URL, c.url
+    assert_equal 42, c.instance_variable_get(:@bar)
+  end
+
+  # test invalid use of new
+  def test_new_07
     Curl::Easy.new(TestServlet.url) do|curl|
       curl.http_post
       assert_equal "POST\n", curl.body_str


### PR DESCRIPTION
Using `Curl::Easy#initialize` in combination with `Curl::Easy.allocate` (instead of a custom implementation of `Curl::Easy.new`) allows subclasses to extend or override argument handling. The unit tests are passing and this change should not introduce any backwards incompatibility.
