### PR TITLE
Update Gemspec to include new homepage url

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   #### Documentation and testing.
   s.has_rdoc = true
-  s.homepage = 'http://curb.rubyforge.org/'
+  s.homepage = 'https://github.com/taf2/curb'
   s.rdoc_options = ['--main', 'README']
 
   s.platform = Gem::Platform::RUBY


### PR DESCRIPTION
The homepage listed in the gemfile now redirects to github
