### PR TITLE
Support CURLOPT_TCP_NODELAY in Curl::Easy

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3129,6 +3129,9 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     VALUE cookiejar = val;
     CURB_OBJECT_HSETTER(ruby_curl_easy, cookiejar);
     } break;
+  case CURLOPT_TCP_NODELAY: {
+    curl_easy_setopt(rbce->curl, CURLOPT_TCP_NODELAY, FIX2LONG(val));
+    } break;
   case CURLOPT_RESUME_FROM: {
     curl_easy_setopt(rbce->curl, CURLOPT_RESUME_FROM, FIX2LONG(val));
     } break;


### PR DESCRIPTION
Expose CURLOPT_TCP_NODELAY. Enabling tcp_nodelay can be a huge performance boost regarding latency for small requests. On linux, nagle algorithm introduces a ~40ms delay on small requests (smaller than MSS).
