### PR TITLE
Raise an exception if curb doesn't know how to handle a CURLOPT

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3141,7 +3141,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     } break;
 #endif
   default:
-    break;
+    rb_raise(rb_eTypeError, "Curb unsupported option");
   }
 
   return val;

--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -28,9 +28,15 @@ module Curl
     #
     def set(opt,val)
       if opt.is_a?(Symbol)
-        setopt(sym2curl(opt), val)
+        option = sym2curl(opt)
       else
-        setopt(opt.to_i, val)
+        option = opt.to_i
+      end
+
+      begin
+        setopt(option, val)
+      rescue TypeError
+        raise TypeError, "Curb doesn't support setting #{opt} [##{option}] option"
       end
     end
 

--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -1022,6 +1022,13 @@ class TestCurbCurlEasy < Test::Unit::TestCase
     end
   end
 
+  def test_set_unsupported_options
+    curl = Curl::Easy.new
+    assert_raises TypeError do
+      curl.set(99999, 1)
+    end
+  end
+
   include TestServerMethods 
 
   def setup


### PR DESCRIPTION
Hello!

I believe this is a better default. When someone bothers to explicitly set a CURLOPT would want to know if the call succeeded or not. This happened to us while debugging what turned out to be a CURLOPT_TCP_NODELAY issue.
