### PR TITLE
Revert "Use 0.0.0.0 rather than user specific IP address."

### DIFF
--- a/tests/bug_issue102.rb
+++ b/tests/bug_issue102.rb
@@ -4,7 +4,7 @@ class BugIssue102 < Test::Unit::TestCase
 
   def test_interface
     test = "https://api.twitter.com/1/users/show.json?screen_name=TwitterAPI&include_entities=true"
-    ip = "0.0.0.0"
+    ip = "192.168.1.61"
 
     c = Curl::Easy.new do |curl|
       curl.url = test


### PR DESCRIPTION
Reverts taf2/curb#187

multiple tests fail when we make this change... need to rethink

```
  1) Error:
test_post_multipart_array_remote(TestCurbCurlEasy):
Curl::Err::ReadError: Failed to open/read local data from file/application
    /Users/taf2/work/curb/lib/curl/easy.rb:72:in `perform'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:651:in `http_post'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:651:in `test_post_multipart_array_remote'

  2) Error:
test_post_multipart_file_remote(TestCurbCurlEasy):
Curl::Err::ReadError: Failed to open/read local data from file/application
    /Users/taf2/work/curb/lib/curl/easy.rb:72:in `perform'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:678:in `http_post'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:678:in `test_post_multipart_file_remote'

  3) Error:
test_post_streaming(TestCurbCurlEasy):
Curl::Err::ReadError: Failed to open/read local data from file/application
    /Users/taf2/work/curb/lib/curl/easy.rb:72:in `perform'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:866:in `http_post'
    /Users/taf2/work/curb/tests/tc_curl_easy.rb:866:in `test_post_streaming'
```
