### PR TITLE
fixed build error with CentOS 5

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3153,6 +3153,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     VALUE cookiejar = val;
     CURB_OBJECT_HSETTER(ruby_curl_easy, cookiejar);
     } break;
+#if HAVE_CURLOPT_SEEKFUNCTION
   case CURLOPT_TCP_NODELAY: {
     curl_easy_setopt(rbce->curl, CURLOPT_TCP_NODELAY, FIX2LONG(val));
     } break;
@@ -3162,6 +3163,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
   case CURLOPT_FAILONERROR: {
     curl_easy_setopt(rbce->curl, CURLOPT_FAILONERROR, FIX2LONG(val));
     } break;
+#endif
 #if HAVE_CURLOPT_GSSAPI_DELEGATION
   case CURLOPT_GSSAPI_DELEGATION: {
     curl_easy_setopt(rbce->curl, CURLOPT_GSSAPI_DELEGATION, FIX2LONG(val));


### PR DESCRIPTION
I got following error on CentOS 5

```
curb_easy.c: In function 'ruby_curl_easy_put_data_set':
curb_easy.c:794: error: 'CURLOPT_SEEKFUNCTION' undeclared (first use in this function)
curb_easy.c:794: error: (Each undeclared identifier is reported only once
curb_easy.c:794: error: for each function it appears in.)
curb_easy.c:794: error: 'curl_seek_callback' undeclared (first use in this function)
curb_easy.c:794: error: expected ')' before 'seek_data_handler'
curb_easy.c:796: error: 'CURLOPT_SEEKDATA' undeclared (first use in this function)
(snip)
make: *** [curb_easy.o] Error 1
```

this issue caused by [this commit](https://github.com/taf2/curb/commit/b092bcbc2e0c8382992d3c1ce54220235fe5baac)

I ignored some function with undeclared options on old environment like centos5. 
