### PR TITLE
allow custom ssl cipher lists

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3172,6 +3172,9 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
   case CURLOPT_FAILONERROR: {
     curl_easy_setopt(rbce->curl, CURLOPT_FAILONERROR, FIX2LONG(val));
     } break;
+  case CURLOPT_SSL_CIPHER_LIST: {
+    curl_easy_setopt(rbce->curl, CURLOPT_SSL_CIPHER_LIST, StringValueCStr(val));
+    } break;
 #if HAVE_CURLOPT_GSSAPI_DELEGATION
   case CURLOPT_GSSAPI_DELEGATION: {
     curl_easy_setopt(rbce->curl, CURLOPT_GSSAPI_DELEGATION, FIX2LONG(val));


### PR DESCRIPTION
e.g.

``` ruby
c = Curl::Easy.new(url) do |curl|
   curl.timeout = 60
   curl.connect_timeout = 60
   curl.setopt(Curl::CURLOPT_SSL_CIPHER_LIST,"SSLv3")
end
```
