### PR TITLE
Added RedHat dependencies installation note

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,10 @@ On Ubuntu, the dependencies can be satisfied by installing the following package
 
     $ sudo apt-get install libcurl3 libcurl3-gnutls libcurl4-openssl-dev
 
+On RedHat:
+
+    $ sudo yum install ruby-devel libcurl-devel openssl-devel
+    
 Curb has fairly extensive RDoc comments in the source. You can build the
 documentation with:
 


### PR DESCRIPTION
This would be handy for those who are trying to gem install curb on centos or rhel.
ruby-devel is needed because curb compilation requires ruby.h