### PR TITLE
Strange problem on OS X

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3125,6 +3125,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
   case CURLOPT_NOPROGRESS:
   case CURLOPT_NOSIGNAL:
   case CURLOPT_HTTPGET:
+    break;
   case CURLOPT_POST: {
     curl_easy_setopt(rbce->curl, CURLOPT_POST, rb_type(val) == T_TRUE);
   } break;


### PR DESCRIPTION
Hi,

I encountered strange issue on OS X version `10.9.5` with Ruby version `2.1.3`, `2.2.0` and `2.2.1`

```ruby
> irb ./play.rb
play.rb(main):001:0> require 'curb'
=> true
play.rb(main):002:0> url = 'http://baidu.com'
=> "http://baidu.com"
play.rb(main):003:0> client = Curl::Easy.new
=> #<Curl::Easy>
play.rb(main):004:0> client.url = url
=> "http://baidu.com"
play.rb(main):005:0> client.http_get
Curl::Err::GotNothingError: Server returned nothing (no headers, no data)
	from /Users/forresty/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/curb-0.8.7/lib/curl/easy.rb:72:in `perform'
	from /Users/forresty/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/curb-0.8.7/lib/curl/easy.rb:294:in `http'
	from /Users/forresty/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/curb-0.8.7/lib/curl/easy.rb:294:in `http_get'
	from ./play.rb:5
	from /Users/forresty/.rbenv/versions/2.1.3/bin/irb:11:in `<main>'
```

I was able to fix this problem with this single line change. Though I've no idea why it works.

In other words, it might not be a good idea to merge this pull request

the problem lies with the `ruby_curl_easy_set_opt` call when calling `Easy#http_get`

therefore, when use `Easy#http` with `:GET` argument directly, there is no problem:

```ruby
play.rb(main):001:0> require 'curb'
=> true
play.rb(main):002:0> url = 'http://baidu.com'
=> "http://baidu.com"
play.rb(main):003:0> client = Curl::Easy.new
=> #<Curl::Easy>
play.rb(main):004:0> client.url = url
=> "http://baidu.com"
play.rb(main):005:0> client.http :GET
=> true
play.rb(main):006:0> puts client.body_str
<html>
<meta http-equiv="refresh" content="0;url=http://www.baidu.com/">
</html>
=> nil
```

After the patch:

```ruby
> irb ./play.rb
play.rb(main):001:0> require 'curb'
=> true
play.rb(main):002:0> url = 'http://baidu.com'
=> "http://baidu.com"
play.rb(main):003:0> client = Curl::Easy.new
=> #<Curl::Easy>
play.rb(main):004:0> client.url = url
=> "http://baidu.com"
play.rb(main):005:0> client.http_get
=> true
play.rb(main):006:0> puts client.body_str
<html>
<meta http-equiv="refresh" content="0;url=http://www.baidu.com/">
</html>
=> nil
```