### PR TITLE
Update curb.gemspec

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -14,15 +14,13 @@ Gem::Specification.new do |s|
   s.summary = %q{Ruby libcurl bindings}
   s.test_files = ["tests/alltests.rb", "tests/bug_crash_on_debug.rb", "tests/bug_crash_on_progress.rb", "tests/bug_curb_easy_blocks_ruby_threads.rb", "tests/bug_curb_easy_post_with_string_no_content_length_header.rb", "tests/bug_instance_post_differs_from_class_post.rb", "tests/bug_issue102.rb", "tests/bug_multi_segfault.rb", "tests/bug_postfields_crash.rb", "tests/bug_postfields_crash2.rb", "tests/bug_require_last_or_segfault.rb", "tests/bugtests.rb", "tests/helper.rb", "tests/mem_check.rb", "tests/require_last_or_segfault_script.rb", "tests/signals.rb", "tests/tc_curl.rb", "tests/tc_curl_download.rb", "tests/tc_curl_easy.rb", "tests/tc_curl_easy_setopt.rb", "tests/tc_curl_multi.rb", "tests/tc_curl_postfield.rb", "tests/timeout.rb", "tests/timeout_server.rb", "tests/unittests.rb"]
   
-    s.extensions << 'ext/extconf.rb'
-  
+  s.extensions << 'ext/extconf.rb'
 
   #### Documentation and testing.
   s.has_rdoc = true
-  s.homepage = 'http://curb.rubyforge.org/'
+  s.homepage = 'https://github.com/taf2/curb'
   s.rdoc_options = ['--main', 'README.markdown']
 
-  
-    s.platform = Gem::Platform::RUBY
+  s.platform = Gem::Platform::RUBY
   
 end


### PR DESCRIPTION
The rubyforge address redirects to github, so update homepage to github.