### PR TITLE
fix Exception to StandardError

### DIFF
--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -6,7 +6,7 @@ module Curl
     alias body body_str
     alias head header_str
 
-    class Error < Exception
+    class Error < StandardError
       attr_accessor :message, :code
       def initialize(code, msg)
         self.message = msg


### PR DESCRIPTION
fix issue #263 , #253 

doc in http://ruby-doc.org/core-2.2.0/Exception.html

[[ Programs may make subclasses of Exception, typically of StandardError or RuntimeError, to provide custom classes and add additional information. See the subclass list below for defaults for raise and rescue. ]]