### PR TITLE
Request specific TLS version with additional constants

### DIFF
--- a/ext/curb.c
+++ b/ext/curb.c
@@ -296,6 +296,9 @@ void Init_curb_core() {
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1",   INT2FIX(CURL_SSLVERSION_TLSv1));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv2",   INT2FIX(CURL_SSLVERSION_SSLv2));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv3",   INT2FIX(CURL_SSLVERSION_SSLv3));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_0",   INT2FIX(CURL_SSLVERSION_TLSv1_0));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_1",   INT2FIX(CURL_SSLVERSION_TLSv1_1));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_2",   INT2FIX(CURL_SSLVERSION_TLSv1_2));
 
   rb_define_const(mCurl, "CURL_USESSL_CONTROL", INT2FIX(CURB_FTPSSL_CONTROL));
   rb_define_const(mCurl, "CURL_USESSL_NONE", INT2FIX(CURB_FTPSSL_NONE));
@@ -306,6 +309,9 @@ void Init_curb_core() {
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1",   INT2FIX(-1));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv2",   INT2FIX(-1));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv3",   INT2FIX(-1));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_0", INT2FIX(-1));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_1", INT2FIX(-1));
+  rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_2", INT2FIX(-1));
 
   rb_define_const(mCurl, "CURL_USESSL_CONTROL", INT2FIX(-1));
   rb_define_const(mCurl, "CURL_USESSL_NONE", INT2FIX(-1));
@@ -885,6 +891,15 @@ void Init_curb_core() {
 #endif
 #if HAVE_CURL_SSLVERSION_SSLv3
   CURB_DEFINE(CURL_SSLVERSION_SSLv3);
+#endif
+#if HAVE_CURL_SSLVERSION_TLSv1_0
+  CURB_DEFINE(CURL_SSLVERSION_TLSv1_0);
+#endif
+#if HAVE_CURL_SSLVERSION_TLSv1_1
+  CURB_DEFINE(CURL_SSLVERSION_TLSv1_1);
+#endif
+#if HAVE_CURL_SSLVERSION_TLSv1_2
+  CURB_DEFINE(CURL_SSLVERSION_TLSv1_2);
 #endif
 #if HAVE_CURLOPT_SSL_VERIFYPEER
   CURB_DEFINE(CURLOPT_SSL_VERIFYPEER);

--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1353,8 +1353,15 @@ static VALUE ruby_curl_easy_password_get(VALUE self, VALUE password) {
  *   easy.ssl_version = value                         => fixnum or nil
  *
  * Sets the version of SSL/TLS that libcurl will attempt to use. Valid
- * options are Curl::CURL_SSLVERSION_TLSv1, Curl::CURL_SSLVERSION::SSLv2,
- * Curl::CURL_SSLVERSION_SSLv3 and Curl::CURL_SSLVERSION_DEFAULT
+ * options are:
+ *
+ *   Curl::CURL_SSLVERSION_DEFAULT
+ *   Curl::CURL_SSLVERSION_TLSv1 (TLS 1.x)
+ *   Curl::CURL_SSLVERSION_SSLv2
+ *   Curl::CURL_SSLVERSION_SSLv3
+ *   Curl::CURL_SSLVERSION_TLSv1_0
+ *   Curl::CURL_SSLVERSION_TLSv1_1
+ *   Curl::CURL_SSLVERSION_TLSv1_2
  */
 static VALUE ruby_curl_easy_ssl_version_set(VALUE self, VALUE ssl_version) {
   CURB_IMMED_SETTER(ruby_curl_easy, ssl_version, -1);

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -321,6 +321,9 @@ have_constant "curl_sslversion_default"
 have_constant :CURL_SSLVERSION_TLSv1
 have_constant :CURL_SSLVERSION_SSLv2
 have_constant :CURL_SSLVERSION_SSLv3
+have_constant :CURL_SSLVERSION_TLSv1_0
+have_constant :CURL_SSLVERSION_TLSv1_1
+have_constant :CURL_SSLVERSION_TLSv1_2
 have_constant "curlopt_ssl_verifypeer"
 have_constant "curlopt_cainfo"
 have_constant "curlopt_issuercert"


### PR DESCRIPTION
Adds support for:

* Curl::CURL_SSLVERSION_TLSv1_0
* Curl::CURL_SSLVERSION_TLSv1_1
* Curl::CURL_SSLVERSION_TLSv1_2

/ping https://github.com/taf2/curb/issues/258