### PR TITLE
Allow setting of CURLOPT_FORBID_REUSE

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3236,6 +3236,9 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
   case CURLOPT_SSL_CIPHER_LIST: {
     curl_easy_setopt(rbce->curl, CURLOPT_SSL_CIPHER_LIST, StringValueCStr(val));
     } break;
+  case CURLOPT_FORBID_REUSE: {
+    curl_easy_setopt(rbce->curl, CURLOPT_FORBID_REUSE, FIX2INT(val))
+    } break;
 #if HAVE_CURLOPT_GSSAPI_DELEGATION
   case CURLOPT_GSSAPI_DELEGATION: {
     curl_easy_setopt(rbce->curl, CURLOPT_GSSAPI_DELEGATION, FIX2LONG(val));

--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3237,7 +3237,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     curl_easy_setopt(rbce->curl, CURLOPT_SSL_CIPHER_LIST, StringValueCStr(val));
     } break;
   case CURLOPT_FORBID_REUSE: {
-    curl_easy_setopt(rbce->curl, CURLOPT_FORBID_REUSE, FIX2INT(val))
+    curl_easy_setopt(rbce->curl, CURLOPT_FORBID_REUSE, FIX2INT(val));
     } break;
 #if HAVE_CURLOPT_GSSAPI_DELEGATION
   case CURLOPT_GSSAPI_DELEGATION: {


### PR DESCRIPTION
When making a lot of curb requests, the connections seem to stay open for quite some time. Curb doesn't reuse these connections though. To prevent the open connections, one might want to set CURLOPT_FORBID_REUSE.