### PR TITLE
Add support for HTTP/2 and Multiplexing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -172,14 +172,25 @@ c.multipart_form_post = true
 c.http_post(Curl::PostField.file('thing[file]', 'myfile.rb'))
 ```
 
+### Using HTTP/2
+
+```ruby
+c = Curl::Easy.new("https://http2.akamai.com")
+c.set(:HTTP_VERSION, Curl::HTTP_2_0)
+
+c.perform
+puts (c.body_str.include? "You are using HTTP/2 right now!") ? "HTTP/2" : "HTTP/1.x"
+```
+
 ### Multi Interface (Basic HTTP GET):
 
 ```ruby
 # make multiple GET requests
 easy_options = {:follow_location => true}
-multi_options = {:pipeline => true}
+# Use Curl::CURLPIPE_MULTIPLEX for HTTP/2 multiplexing
+multi_options = {:pipeline => Curl::CURLPIPE_HTTP1} 
 
-Curl::Multi.get('url1','url2','url3','url4','url5', easy_options, multi_options) do|easy|
+Curl::Multi.get(['url1','url2','url3','url4','url5'], easy_options, multi_options) do|easy|
   # do something interesting with the easy response
   puts easy.last_effective_url
 end
@@ -190,7 +201,8 @@ end
 ```ruby
 # make multiple POST requests
 easy_options = {:follow_location => true, :multipart_form_post => true}
-multi_options = {:pipeline => true}
+multi_options = {:pipeline => Curl::CURLPIPE_HTTP1}
+
 
 url_fields = [
   { :url => 'url1', :post_fields => {'f1' => 'v1'} },

--- a/Rakefile
+++ b/Rakefile
@@ -69,7 +69,7 @@ desc "Compile the shared object"
 task :compile => [CURB_SO]
 
 desc "Install to your site_ruby directory"
-task :install => :alltests do
+task :install do
   m = make 'install' 
   fail "Make install failed (status #{m})" unless m == 0
 end

--- a/bench/curb_multi.rb
+++ b/bench/curb_multi.rb
@@ -15,7 +15,7 @@ Memory.usage("Curl::Multi.pipelined(#{N})") do
   count = 0
   multi = Curl::Multi.new
 
-  multi.pipeline = true
+  multi.pipeline = Curl::CURLPIPE_HTTP1
   multi.max_connects = 10
 
   # maintain a free list of easy handles, better to reuse an open connection than create a new one...

--- a/ext/curb.c
+++ b/ext/curb.c
@@ -591,6 +591,9 @@ void Init_curb_core() {
     CURB_DEFINE(CURL_HTTP_VERSION_NONE);
     CURB_DEFINE(CURL_HTTP_VERSION_1_0);
     CURB_DEFINE(CURL_HTTP_VERSION_1_1);
+#if LIBCURL_VERSION_NUM >= 0x072100 /* 7.33.0 */
+    CURB_DEFINE(CURL_HTTP_VERSION_2_0);
+#endif
 #if HAVE_CURLOPT_IGNORE_CONTENT_LENGTH
   CURB_DEFINE(CURLOPT_IGNORE_CONTENT_LENGTH);
 #endif
@@ -1005,12 +1008,24 @@ void Init_curb_core() {
   CURB_DEFINE(CURLOPT_UNIX_SOCKET_PATH);
 #endif
 
+#if LIBCURL_VERSION_NUM >= 0x072B00 /* 7.43.0 */
+  CURB_DEFINE(CURLPIPE_NOTHING);
+  CURB_DEFINE(CURLPIPE_HTTP1);
+  CURB_DEFINE(CURLPIPE_MULTIPLEX);
+
+  rb_define_const(mCurl, "PIPE_NOTHING", LONG2NUM(CURLPIPE_NOTHING));
+  rb_define_const(mCurl, "PIPE_HTTP1", LONG2NUM(CURLPIPE_HTTP1));
+  rb_define_const(mCurl, "PIPE_MULTIPLEX", LONG2NUM(CURLPIPE_MULTIPLEX));
+#endif
+
 #if LIBCURL_VERSION_NUM >= 0x072100 /* 7.33.0 */
   rb_define_const(mCurl, "HTTP_2_0", LONG2NUM(CURL_HTTP_VERSION_2_0));
 #endif
   rb_define_const(mCurl, "HTTP_1_1", LONG2NUM(CURL_HTTP_VERSION_1_1));
   rb_define_const(mCurl, "HTTP_1_0", LONG2NUM(CURL_HTTP_VERSION_1_0));
   rb_define_const(mCurl, "HTTP_NONE", LONG2NUM(CURL_HTTP_VERSION_NONE));
+
+
 
   rb_define_singleton_method(mCurl, "ipv6?", ruby_curl_ipv6_q, 0);
   rb_define_singleton_method(mCurl, "kerberos4?", ruby_curl_kerberos4_q, 0);

--- a/lib/curb.gemspec.erb
+++ b/lib/curb.gemspec.erb
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   <% else %>
     s.platform = Gem::Platform::RUBY
   <% end %>
+  s.licenses = ['MIT']
 end

--- a/lib/curl/multi.rb
+++ b/lib/curl/multi.rb
@@ -22,7 +22,7 @@ module Curl
       #                     {:url => 'url2', :post_fields => {'field1' => 'value1', 'field2' => 'value2'}},
       #                     {:url => 'url3', :post_fields => {'field1' => 'value1', 'field2' => 'value2'}}],
       #                    { :follow_location => true, :multipart_form_post => true },
-      #                    {:pipeline => true }) do|easy|
+      #                    {:pipeline => Curl::CURLPIPE_HTTP1}) do|easy|
       #     easy_handle_on_request_complete
       #   end
       # 
@@ -46,7 +46,7 @@ module Curl
       #                    {:url => 'url2', :put_data => IO.read('filepath')},
       #                    {:url => 'url3', :put_data => "maybe another string or socket?"],
       #                    {:follow_location => true},
-      #                    {:pipeline => true }) do|easy|
+      #                    {:pipeline => Curl::CURLPIPE_HTTP1}) do|easy|
       #     easy_handle_on_request_complete
       #   end
       # 
@@ -74,7 +74,7 @@ module Curl
       #     :follow_location => true, :max_redirects => 3 },
       #   { :url => 'url3', :method => :put, :put_data => File.open('file.txt','rb') },
       #   { :url => 'url4', :method => :head }
-      # ], {:pipeline => true})
+      # ], {:pipeline => Curl::CURLPIPE_HTTP1})
       #
       # Blocking call to issue multiple HTTP requests with varying verb's.
       #


### PR DESCRIPTION
This patch adds support for a bunch of libcurl options for HTTP/2 support:

```ruby
Curl::CURL_HTTP_VERSION_2_0
Curl::HTTP_VERSION_2_0
Curl::CURLPIPE_NOTHING # same as pipeline=false before
Curl::CURLPIPE_HTTP1 # same as pipeline=true before
Curl::CURLPIPE_MULTIPLEX # HTTP/2 multiplexing
Curl::PIPE_NOTHING
Curl::PIPE_HTTP1
Curl::PIPE_MULTIPLEX
```

It _should_ maintain backwards compatibility with the old `pipeline` boolean values, as well as supporting the new multiplex option, and the corresponding ints that true/false represented, but I'm not that proficient at C, and have never hacked on a ruby gem before, so please do review carefully!