### PR TITLE
Support empty reason phrases in the HTTP status line

### DIFF
--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -20,7 +20,7 @@ module Curl
     #
     def status
       # Matches the last HTTP Status - following the HTTP protocol specification 'Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF'
-      statuses = self.header_str.scan(/HTTP\/\d\.\d\s(\d+\s.+)\r\n/).map{ |match|  match[0] }
+      statuses = self.header_str.scan(/HTTP\/\d\.\d\s(\d+\s.*)\r\n/).map{ |match|  match[0] }
       statuses.last.strip
     end
 


### PR DESCRIPTION
The reason phrase may be empty, see RFC 7230 section 3.1.2