### PR TITLE
Add a require statement to help with new users who are getting started with curb

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,6 +65,12 @@ Curb provides two classes:
 * `Curl::Easy` - simple API, for day-to-day tasks.
 * `Curl::Multi` - more advanced API, for operating on multiple URLs simultaneously.
 
+To use either, you will need to require the curb gem:
+
+```ruby
+require 'curb'
+```
+
 ### Super simple API (less typing)
 
 ```ruby


### PR DESCRIPTION
The curb modules are `Curl`, which makes it unclear to new ruby users as to what they should be requiring.

Opened this PR as I'm going through some ruby basics with someone and they were confused by the module naming schema vs. the gem name.