### PR TITLE
Fix discrepancy between gemspec and LICENSE

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   
     s.platform = Gem::Platform::RUBY
   
-  s.licenses = ['MIT']
+  s.licenses = ['Ruby']
 end


### PR DESCRIPTION
The license outlined in LICENSE is the Ruby license, whereas the license given in the gemspec was MIT.
