### PR TITLE
Goodbye Rubyforge

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   #### Documentation and testing.
   s.has_rdoc = true
-  s.homepage = 'http://curb.rubyforge.org/'
+  s.homepage = 'https://github.com/taf2/curb'
   s.rdoc_options = ['--main', 'README.markdown']
 
   


### PR DESCRIPTION
The Rubyforge URL redirects to this repo, so I updated the URL in the gemspec to point here directly.