### PR TITLE
Make tests work on Windows

### DIFF
--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -18,7 +18,7 @@ rescue LoadError
 end
 require 'fileutils'
 
-$TEST_URL = "file://#{URI.escape(File.expand_path(__FILE__).tr('\\','/').tr(':','|'))}"
+$TEST_URL = "file://#{URI.escape(File.expand_path(__FILE__).tr('\\','/'))}"
 
 require 'thread'
 require 'webrick'


### PR DESCRIPTION
On my Windows (10 x64-mingw) dev box, tests were failing because of a malformed URL. This tiny PR fixes that.