### PR TITLE
Add Curl::Easy#resolve method to implement static IP overrides, bypassing DNS

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -2327,10 +2327,10 @@ VALUE ruby_curl_easy_setup(ruby_curl_easy *rbce) {
   }
 
   /* Setup resolve list if necessary */
-  if (!rb_easy_nil("resolve_list")) {
-    if (rb_easy_type_check("resolve_list", T_ARRAY)) {
+  if (!rb_easy_nil("resolve")) {
+    if (rb_easy_type_check("resolve", T_ARRAY)) {
       VALUE wrap = Data_Wrap_Struct(rb_cObject, 0, 0, rslv);
-      rb_iterate(rb_each, rb_easy_get("resolve_list"), cb_each_resolve, wrap);
+      rb_iterate(rb_each, rb_easy_get("resolve"), cb_each_resolve, wrap);
     }
 
     if (*rslv) {

--- a/ext/curb_easy.h
+++ b/ext/curb_easy.h
@@ -77,6 +77,7 @@ typedef struct {
 
   struct curl_slist *curl_headers;
   struct curl_slist *curl_ftp_commands;
+  struct curl_slist *curl_resolve;
 
   int last_result; /* last result code from multi loop */
 

--- a/tests/tc_curl_easy_resolve.rb
+++ b/tests/tc_curl_easy_resolve.rb
@@ -13,11 +13,4 @@ class TestCurbCurlEasyResolve < Test::Unit::TestCase
   def test_empty_resolve
     assert_equal @easy.resolve, nil
   end
-
-#  def test_opt_url
-#    url = "http://google.com/"
-#    @easy.set :url, url
-#    assert_equal url, @easy.url
-#  end
-
 end

--- a/tests/tc_curl_easy_resolve.rb
+++ b/tests/tc_curl_easy_resolve.rb
@@ -1,0 +1,23 @@
+require File.expand_path(File.join(File.dirname(__FILE__), 'helper'))
+
+class TestCurbCurlEasyResolve < Test::Unit::TestCase
+  def setup
+    @easy = Curl::Easy.new
+  end
+
+  def test_resolve
+    @easy.resolve = [ "example.com:80:127.0.0.1" ]
+    assert_equal @easy.resolve, [ "example.com:80:127.0.0.1" ]
+  end
+
+  def test_empty_resolve
+    assert_equal @easy.resolve, nil
+  end
+
+#  def test_opt_url
+#    url = "http://google.com/"
+#    @easy.set :url, url
+#    assert_equal url, @easy.url
+#  end
+
+end


### PR DESCRIPTION
As discussed in #49, there currently is no way to set the CURLOPT_RESOLVE list. This is needed when SSL backend servers need to be accessed on a different IP address than listed in the DNS. One use case is for checking multiple SSL backend servers for consistency.

The pull request includes unit tests for the new setter and getter methods, and docstrings that hopefully clarify the usage.