### PR TITLE
Prevent `NoMethodError` when no HTTP Status

### DIFF
--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -21,7 +21,7 @@ module Curl
     def status
       # Matches the last HTTP Status - following the HTTP protocol specification 'Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF'
       statuses = self.header_str.scan(/HTTP\/\d\.\d\s(\d+\s.*)\r\n/).map{ |match|  match[0] }
-      statuses.last.strip
+      statuses.last.strip if statuses.length > 0
     end
 
     #


### PR DESCRIPTION
While it violates the protocol for the status line not to be there, the current `NoMethodError` error that results is confusing.