### PR TITLE
extconf.rb: Fix SSL versions constant names

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,8 +11,8 @@ Curb is a work-in-progress, and currently only supports libcurl's 'easy' and 'mu
 
 ## License
 
-Curb is copyright (c)2006 Ross Bamford, and released under the terms of the 
-Ruby license. See the LICENSE file for the gory details. 
+Curb is copyright (c)2006 Ross Bamford, and released under the terms of the
+Ruby license. See the LICENSE file for the gory details.
 
 ## You will need
 
@@ -32,17 +32,17 @@ line (alter paths to your curl location, but remember to use forward slashes):
 
     gem install curb --platform=ruby -- --with-curl-lib=C:/curl-7.39.0-devel-mingw32/bin --with-curl-include=C:/curl-7.39.0-devel-mingw32/include
 
-Or, if you downloaded the archive:  
+Or, if you downloaded the archive:
 
-    $ rake install 
+    $ rake compile && rake install
 
 If you have a weird setup, you might need extconf options. In this case, pass
 them like so:
 
-    $ rake install EXTCONF_OPTS='--with-curl-dir=/path/to/libcurl --prefix=/what/ever'
-  
+    $ rake compile EXTCONF_OPTS='--with-curl-dir=/path/to/libcurl --prefix=/what/ever' && rake install
+
 Curb is tested only on GNU/Linux x86 and Mac OSX - YMMV on other platforms.
-If you do use another platform and experience problems, or if you can 
+If you do use another platform and experience problems, or if you can
 expand on the above instructions, please report the issue at http://github.com/taf2/curb/issues
 
 On Ubuntu, the dependencies can be satisfied by installing the following packages:
@@ -52,7 +52,7 @@ On Ubuntu, the dependencies can be satisfied by installing the following package
 On RedHat:
 
     $ sudo yum install ruby-devel libcurl-devel openssl-devel
-    
+
 Curb has fairly extensive RDoc comments in the source. You can build the
 documentation with:
 
@@ -104,7 +104,7 @@ puts c.body_str
 ### Additional config:
 
 ```ruby
-Curl::Easy.perform("http://www.google.co.uk") do |curl| 
+Curl::Easy.perform("http://www.google.co.uk") do |curl|
   curl.headers["User-Agent"] = "myapp-0.0"
   curl.verbose = true
 end
@@ -113,7 +113,7 @@ end
 Same thing, more manual:
 
 ```ruby
-c = Curl::Easy.new("http://www.google.co.uk") do |curl| 
+c = Curl::Easy.new("http://www.google.co.uk") do |curl|
   curl.headers["User-Agent"] = "myapp-0.0"
   curl.verbose = true
 end
@@ -194,7 +194,7 @@ puts (c.body_str.include? "You are using HTTP/2 right now!") ? "HTTP/2" : "HTTP/
 # make multiple GET requests
 easy_options = {:follow_location => true}
 # Use Curl::CURLPIPE_MULTIPLEX for HTTP/2 multiplexing
-multi_options = {:pipeline => Curl::CURLPIPE_HTTP1} 
+multi_options = {:pipeline => Curl::CURLPIPE_HTTP1}
 
 Curl::Multi.get(['url1','url2','url3','url4','url5'], easy_options, multi_options) do|easy|
   # do something interesting with the easy response

--- a/ext/curb.c
+++ b/ext/curb.c
@@ -272,15 +272,15 @@ void Init_curb_core() {
   /* Passed to on_debug handler to indicate that the data is protocol data sent to the peer. */
   rb_define_const(mCurl, "CURLINFO_DATA_OUT", LONG2NUM(CURLINFO_DATA_OUT));
 
-#ifdef HAVE_CURLFTPMETHOD_MULTICWD 
+#ifdef HAVE_CURLFTPMETHOD_MULTICWD
   rb_define_const(mCurl, "CURL_MULTICWD",  LONG2NUM(CURLFTPMETHOD_MULTICWD));
 #endif
 
-#ifdef HAVE_CURLFTPMETHOD_NOCWD 
+#ifdef HAVE_CURLFTPMETHOD_NOCWD
   rb_define_const(mCurl, "CURL_NOCWD",     LONG2NUM(CURLFTPMETHOD_NOCWD));
 #endif
 
-#ifdef HAVE_CURLFTPMETHOD_SINGLECWD 
+#ifdef HAVE_CURLFTPMETHOD_SINGLECWD
   rb_define_const(mCurl, "CURL_SINGLECWD", LONG2NUM(CURLFTPMETHOD_SINGLECWD));
 #endif
 
@@ -296,13 +296,13 @@ void Init_curb_core() {
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1",   LONG2NUM(CURL_SSLVERSION_TLSv1));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv2",   LONG2NUM(CURL_SSLVERSION_SSLv2));
   rb_define_const(mCurl, "CURL_SSLVERSION_SSLv3",   LONG2NUM(CURL_SSLVERSION_SSLv3));
-#if HAVE_CURL_SSLVERSION_TLSv1_0
+#if HAVE_CURL_SSLVERSION_TLSV1_0
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_0",   LONG2NUM(CURL_SSLVERSION_TLSv1_0));
 #endif
-#if HAVE_CURL_SSLVERSION_TLSv1_1
+#if HAVE_CURL_SSLVERSION_TLSV1_1
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_1",   LONG2NUM(CURL_SSLVERSION_TLSv1_1));
 #endif
-#if HAVE_CURL_SSLVERSION_TLSv1_2
+#if HAVE_CURL_SSLVERSION_TLSV1_2
   rb_define_const(mCurl, "CURL_SSLVERSION_TLSv1_2",   LONG2NUM(CURL_SSLVERSION_TLSv1_2));
 #endif
 

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -322,14 +322,14 @@ have_constant "curlopt_sslengine"
 have_constant "curlopt_sslengine_default"
 have_constant "curlopt_sslversion"
 have_constant "curl_sslversion_default"
-have_constant "curl_sslversion_tlsv1"
-have_constant "curl_sslversion_sslv2"
-have_constant "curl_sslversion_sslv3"
+have_constant :CURL_SSLVERSION_TLSv1
+have_constant :CURL_SSLVERSION_SSLv2
+have_constant :CURL_SSLVERSION_SSLv3
 
 # Added in 7.34.0
-have_constant "curl_sslversion_tlsv1_0"
-have_constant "curl_sslversion_tlsv1_1"
-have_constant "curl_sslversion_tlsv1_2"
+have_constant :CURL_SSLVERSION_TLSv1_0
+have_constant :CURL_SSLVERSION_TLSv1_1
+have_constant :CURL_SSLVERSION_TLSv1_2
 
 have_constant "curlopt_ssl_verifypeer"
 have_constant "curlopt_cainfo"


### PR DESCRIPTION
The `have_constant` method puts the whole constant name to upcase, but the various ssl versions constants aren't fully upcase, so they're never found.  This patch updates those constants to use a symbol with the right case.

This PR also updates the README to reflect the need to run `rake compile` before `rake install` to have the makefile generated.

Sadly, the PR also includes a few spacing changes I was too lazy to remove, tell me if this is a problem.

Cheers,
Lta.

Signed-off-by: Julien 'Lta' BALLET <contact@lta.io>