### PR TITLE
Support HTTP/2 status header

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
   * use rb_thread_blocking_region when available in place of rb_thread_select for ruby 1.9.x
+  * Support the status response according to HTTP/2 RFC
 0.7.16
   * Add better support for timeouts issue 48
   * Improve stablity, avoid bus errors when raising in callbacks
@@ -9,7 +10,7 @@
   * Minor refactoring to how PostField.file handles strings
   * Accept symbol and any object that responds_to?(:to_s) for easy.http(:verb)
   * Free memory sooner after a request finishes instead of waiting for garabage collection
-  * Fix crash when sending nil for the http_put body 
+  * Fix crash when sending nil for the http_put body
   * Fix inspect for Curl::Easy, thanks Hongli Lai
   * Fix unit test assertions for Curl::Multi, thanks Hongli Lai
 0.7.7

--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -19,8 +19,8 @@ module Curl
     #   easy.status  => String
     #
     def status
-      # Matches the last HTTP Status - following the HTTP protocol specification 'Status-Line = HTTP-Version SP Status-Code SP Reason-Phrase CRLF'
-      statuses = self.header_str.scan(/HTTP\/\d\.\d\s(\d+\s.*)\r\n/).map{ |match|  match[0] }
+      # Matches the last HTTP Status - following the HTTP protocol specification 'Status-Line = HTTP-Version SP Status-Code SP (Opt:)Reason-Phrase CRLF'
+      statuses = self.header_str.scan(/HTTP\/\d(\.\d)?\s(\d+\s.*)\r\n/).map{ |match| match[1] }
       statuses.last.strip if statuses.length > 0
     end
 


### PR DESCRIPTION
The HTTP/2 RFC specifies the status header as HTTP/2 200 CRLF, it's not
mandatory to return the number as float, nor do they add the status info
anymore.

This PR fixes it so it is still able to work with HTTP/2