### PR TITLE
do not append `?` to urls if there are no query parameters

### DIFF
--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -52,12 +52,7 @@ module Curl
     return uri.to_s if params.empty?
 
     params_query = URI.encode_www_form(params || {})
-    # both uri.query and params_query not blank
-    if !uri.query.to_s.empty? && !params_query.empty?
-      uri.query = "#{uri.query}&#{params_query}"
-    else
-      uri.query = "#{uri.query}#{params_query}"
-    end
+    uri.query = [uri.query.to_s, params_query].reject(&:empty?).join('&')
     uri.to_s
   end
 

--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -49,7 +49,7 @@ module Curl
   def self.urlalize(url, params={})
     uri = URI(url)
     # early return if we didn't specify any extra params
-    return uri.to_s if params.empty?
+    return uri.to_s if (params || {}).empty?
 
     params_query = URI.encode_www_form(params || {})
     uri.query = [uri.query.to_s, params_query].reject(&:empty?).join('&')

--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -48,9 +48,12 @@ module Curl
 
   def self.urlalize(url, params={})
     uri = URI(url)
+    # early return if we didn't specify any extra params
+    return uri.to_s if params.empty?
+
     params_query = URI.encode_www_form(params || {})
     # both uri.query and params_query not blank
-    if !(uri.query.nil? || uri.query.empty?) && !params_query.empty?
+    if !uri.query.to_s.empty? && !params_query.empty?
       uri.query = "#{uri.query}&#{params_query}"
     else
       uri.query = "#{uri.query}#{params_query}"

--- a/tests/tc_curl.rb
+++ b/tests/tc_curl.rb
@@ -31,6 +31,31 @@ class TestCurl < Test::Unit::TestCase
     assert_equal "OPTIONSfoo=bar", curl.body_str
   end
 
+  def test_urlalize_without_extra_params
+    url_no_params = 'http://localhost/test'
+    url_with_params = 'http://localhost/test?a=1'
+
+    assert_equal(url_no_params, Curl.urlalize(url_no_params))
+    assert_equal(url_with_params, Curl.urlalize(url_with_params))
+  end
+
+  def test_urlalize_with_extra_params
+    url_no_params = 'http://localhost/test'
+    url_with_params = 'http://localhost/test?a=1'
+    extra_params = { :b => 2 }
+
+    expected_url_no_params = 'http://localhost/test?b=2'
+    expected_url_with_params = 'http://localhost/test?a=1&b=2'
+
+    assert_equal(expected_url_no_params, Curl.urlalize(url_no_params, extra_params))
+    assert_equal(expected_url_with_params, Curl.urlalize(url_with_params, extra_params))
+  end
+
+  def test_urlalize_does_not_strip_trailing_?
+    url_empty_params = 'http://localhost/test?'
+    assert_equal(url_empty_params, Curl.urlalize(url_empty_params))
+  end
+
   include TestServerMethods
 
   def setup

--- a/tests/tc_curl.rb
+++ b/tests/tc_curl.rb
@@ -39,6 +39,11 @@ class TestCurl < Test::Unit::TestCase
     assert_equal(url_with_params, Curl.urlalize(url_with_params))
   end
 
+  def test_urlalize_with_nil_as_params
+    url = 'http://localhost/test'
+    assert_equal(url, Curl.urlalize(url, nil))
+  end
+
   def test_urlalize_with_extra_params
     url_no_params = 'http://localhost/test'
     url_with_params = 'http://localhost/test?a=1'


### PR DESCRIPTION
Given an URL without query params Curb would add `?` at the end. This
has been introduced in commit 32fa6d7.

This happens because we set `uri.query` to empty string and URI will
treat this as a valid query and it will add `?`. This does not happen
when the query is set to nil.

I have decide to early return if extra parameters are not passed. It
will work whatever there were query params in the original url or not
because we don't change `#query` and it's set correctly.

Added unit tests for all use cases.

The empty `?` is meangingless for the browser/server, but it can be
significant for caching strategies. I use `curb` to purge Varnish
cache for individual urls and addition of `?` breaks this because
the purged URL is different from what I expected.