### PR TITLE
fix small readme mistake

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ On Windows, make sure you're using the [DevKit](http://rubyinstaller.org/downloa
 the [development version of libcurl](http://curl.haxx.se/gknw.net/7.39.0/dist-w32/curl-7.39.0-devel-mingw32.zip). Unzip, then run this in your command
 line (alter paths to your curl location, but remember to use forward slashes):
 
-    gem install curb --platform=ruby -- --with-curl-lib=C:/curl-7.39.0-devel-mingw32/bin --with-curl-include=C:/curl-7.39.0-devel-mingw32/include
+    gem install curb --platform=ruby -- --with-curl-lib=C:/curl-7.39.0-devel-mingw32/lib --with-curl-include=C:/curl-7.39.0-devel-mingw32/include
 
 Or, if you downloaded the archive:
 


### PR DESCRIPTION
There's small trouble I found while installing curb on Windows machine. Fix in readme allows to avoid it.