### PR TITLE
fix `bundle install --deployment`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.5)
+    curb (0.9.6)
 
 GEM
   remote: https://rubygems.org/
@@ -191,6 +191,7 @@ GEM
     rubysl-singleton (2.0.0)
     rubysl-socket (2.2.1)
       rubysl-fcntl (~> 2.0)
+    rubysl-stringio (2.1)
     rubysl-stringio (2.1.0)
     rubysl-strscan (2.0.0)
     rubysl-sync (2.0.0)
@@ -229,3 +230,6 @@ DEPENDENCIES
   rubysl (~> 2.0)
   rubysl-test-unit
   test-unit
+
+BUNDLED WITH
+   1.16.2

--- a/curb.gemspec
+++ b/curb.gemspec
@@ -6,24 +6,18 @@ Gem::Specification.new do |s|
   s.description = %q{Curb (probably CUrl-RuBy or something) provides Ruby-language bindings for the libcurl(3), a fully-featured client-side URL transfer library. cURL and libcurl live at http://curl.haxx.se/}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.markdown']
-  
+
   s.files = ["LICENSE", "README.markdown", "Rakefile", "doc.rb", "ext/extconf.rb", "lib/curl/easy.rb", "lib/curl/multi.rb", "lib/curb.rb", "lib/curl.rb", "ext/curb_easy.c", "ext/curb.c", "ext/curb_multi.c", "ext/curb_upload.c", "ext/curb_postfield.c", "ext/curb_errors.c", "ext/curb_postfield.h", "ext/curb_errors.h", "ext/curb_easy.h", "ext/curb_macros.h", "ext/curb.h", "ext/curb_upload.h", "ext/curb_multi.h"]
   #### Load-time details
   s.require_paths = ['lib','ext']
   s.rubyforge_project = 'curb'
   s.summary = %q{Ruby libcurl bindings}
-  s.test_files = ["tests/tc_curl_multi.rb", "tests/alltests.rb", "tests/tc_curl_easy_setopt.rb", "tests/tc_curl.rb", "tests/bug_postfields_crash.rb", "tests/bug_crash_on_progress.rb", "tests/helper.rb", "tests/bug_postfields_crash2.rb", "tests/bug_require_last_or_segfault.rb", "tests/timeout.rb", "tests/bug_crash_on_debug.rb", "tests/unittests.rb", "tests/bug_issue102.rb", "tests/bug_curb_easy_blocks_ruby_threads.rb", "tests/bug_multi_segfault.rb", "tests/bug_instance_post_differs_from_class_post.rb", "tests/require_last_or_segfault_script.rb", "tests/timeout_server.rb", "tests/tc_curl_download.rb", "tests/tc_curl_easy.rb", "tests/mem_check.rb", "tests/tc_curl_postfield.rb", "tests/bugtests.rb", "tests/tc_curl_easy_resolve.rb", "tests/signals.rb", "tests/bug_curb_easy_post_with_string_no_content_length_header.rb"]
-  
-    s.extensions << 'ext/extconf.rb'
-  
+
+  s.extensions << 'ext/extconf.rb'
 
   #### Documentation and testing.
-  s.has_rdoc = true
   s.homepage = 'http://curb.rubyforge.org/'
   s.rdoc_options = ['--main', 'README.markdown']
-
-  
-    s.platform = Gem::Platform::RUBY
-  
+  s.platform = Gem::Platform::RUBY
   s.licenses = ['MIT']
 end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -97,7 +97,7 @@ class TestServlet < WEBrick::HTTPServlet::AbstractServlet
       if params and params['s'] == '500'
         res.status = 500
       elsif params and params['c']
-        cookie = URI.decode_www_form(params['c'])[0][0].split('=')
+        cookie = URI.decode_www_form_component(params['c']).split('=')
         res.cookies << WEBrick::Cookie.new(*cookie)
       else
         respond_with("POST\n#{req.body}",req,res)


### PR DESCRIPTION
Travis runs `bundle install --deployment` and it fails because the
Gemfile.lock is not up to date.

`curb` version has been updated, but `bundle install` has not been
executed. Bundler is expected to fail with `--deployment` flag if
Gemfile.lock is not up to date.

This commit also removes deprecated fields from the gemspec file.