### PR TITLE
fixes for ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ matrix:
   allow_failures:
    - rvm: rbx-3
   fast_finish: true
+  include:
+    - rvm: 1.8.7
+      dist: precise
+      install: bundle install --gemfile=Gemfile.ruby-1.8
 cache: bundler
 before_install:
   - gem update bundler

--- a/Gemfile.ruby-1.8
+++ b/Gemfile.ruby-1.8
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'rake', '< 12' # as of 12.0 rake requires ruby 1.9
+gem 'test-unit', '< 3'

--- a/Gemfile.ruby-1.8.lock
+++ b/Gemfile.ruby-1.8.lock
@@ -1,0 +1,21 @@
+PATH
+  remote: .
+  specs:
+    curb (0.9.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rake (10.5.0)
+    test-unit (2.5.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  curb!
+  rake (< 12)
+  test-unit (< 3)
+
+BUNDLED WITH
+   1.15.4

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,6 @@
 # 
 require 'rake/clean'
 require 'rake/testtask'
-begin
-  require 'rdoc/task'
-rescue LoadError => e
-  require 'rake/rdoctask'
-end
 
 CLEAN.include '**/*.o'
 CLEAN.include "**/*.#{(defined?(RbConfig) ? RbConfig : Config)::MAKEFILE_CONFIG['DLEXT']}"
@@ -89,12 +84,12 @@ if ENV['RELTEST']
 else
   task :alltests => [:unittests, :bugtests]
 end
-                    
+
 Rake::TestTask.new(:unittests) do |t|
   t.test_files = FileList['tests/tc_*.rb']
   t.verbose = false
 end
-                          
+
 Rake::TestTask.new(:bugtests) do |t|
   t.test_files = FileList['tests/bug_*.rb']
   t.verbose = false
@@ -136,6 +131,12 @@ end
 
 desc "Publish the RDoc documentation to project web site"
 task :doc_upload => [ :doc ] do
+  begin
+    require 'rdoc/task'
+  rescue LoadError => e
+    require 'rake/rdoctask'
+  end
+
   if ENV['RELTEST']
     announce "Release Task Testing, skipping doc upload"
   else    

--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -608,7 +608,7 @@ class TestCurbCurlEasy < Test::Unit::TestCase
   def test_cookielist
     c = Curl::Easy.new TestServlet.url
     c.enable_cookies = true
-    c.post_body = URI.encode_www_form c: 'somename=somevalue'
+    c.post_body = URI.encode_www_form('c' => 'somename=somevalue')
     assert_nil c.cookielist
     c.perform
     assert_match(/somevalue/, c.cookielist.join(''))


### PR DESCRIPTION
Fixes #304 (details in commit messages)

It also enables builds against ruby 1.8 on Travis (new Gemfile with minimal gems and backports was required).

Ruby 1.8 is long dead, but the fix is simple and it will allow anyone still stuck on 1.8 to upgrade easier. With Travis configured the drop of support becomes an option rather than a fact ;)