### PR TITLE
move easy handles tracking in @requests from C to Ruby

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -343,7 +343,8 @@ static VALUE ruby_curl_easy_initialize(int argc, VALUE *argv, VALUE self) {
 
   rb_easy_set("url", url);
 
-  /* set the new_curl pointer to the curl handle */
+
+  /* set the pointer to the curl handle */
   ecode = curl_easy_setopt(rbce->curl, CURLOPT_PRIVATE, (void*)self);
   if (ecode != CURLE_OK) {
     raise_curl_easy_error_exception(ecode);
@@ -2061,7 +2062,6 @@ VALUE ruby_curl_easy_setup(ruby_curl_easy *rbce) {
   }
 
   url = rb_check_string_type(_url);
-
   curl_easy_setopt(curl, CURLOPT_URL, StringValuePtr(url));
 
   // network stuff and auth

--- a/ext/curb_multi.h
+++ b/ext/curb_multi.h
@@ -14,7 +14,6 @@
 typedef struct {
   int active;
   int running;
-  VALUE requests; /* hash of handles currently added */
   CURLM *handle;
 } ruby_curl_multi;
 

--- a/lib/curl/multi.rb
+++ b/lib/curl/multi.rb
@@ -1,5 +1,4 @@
 module Curl
-
   class Multi
     class << self
       # call-seq:
@@ -168,6 +167,7 @@ module Curl
           end
           free_handles = nil
         end
+
       end
 
       # call-seq:
@@ -242,7 +242,34 @@ module Curl
         }
         raise errors unless errors.empty?
       end
+    end
 
+    def cancel!
+      requests.each do |_,easy|
+        remove(easy)
+      end
+    end
+
+    def idle?
+      requests.empty?
+    end
+
+    def requests
+      @requests ||= {}
+    end
+
+    def add(easy)
+      return self if requests[easy.object_id]
+      requests[easy.object_id] = easy
+      _add(easy)
+      self
+    end
+
+    def remove(easy)
+      return self if !requests[easy.object_id]
+      requests.delete(easy.object_id)
+      _remove(easy)
+      self
     end
   end
 end

--- a/tests/tc_curl_multi.rb
+++ b/tests/tc_curl_multi.rb
@@ -125,7 +125,7 @@ class TestCurbCurlMulti < Test::Unit::TestCase
   def test_requests
     m = Curl::Multi.new
 
-    assert_equal([], m.requests, 'A new Curl::Multi handle should have no requests')
+    assert_equal(0, m.requests.length, 'A new Curl::Multi handle should have no requests')
 
     10.times do
       m.add(Curl::Easy.new($TEST_URL))
@@ -135,7 +135,7 @@ class TestCurbCurlMulti < Test::Unit::TestCase
 
     m.perform
 
-    assert_equal([], m.requests, 'A new Curl::Multi handle should have no requests after a perform')
+    assert_equal(0, m.requests.length, 'A new Curl::Multi handle should have no requests after a perform')
   end
 
   def test_cancel
@@ -148,7 +148,7 @@ class TestCurbCurlMulti < Test::Unit::TestCase
 
     m.cancel!
 
-    assert_equal([], m.requests, 'A new Curl::Multi handle should have no requests after being canceled')
+    assert_equal(0, m.requests.size, 'A new Curl::Multi handle should have no requests after being canceled')
   end
 
   def test_with_success
@@ -192,7 +192,7 @@ class TestCurbCurlMulti < Test::Unit::TestCase
     c1.on_success do|c|
       success_called1 = true
       #puts "success 1 called: #{c.body_str.inspect}"
-      #assert_match(/^# DO NOT REMOVE THIS COMMENT/, c.body_str)
+      assert_match(/^# DO NOT REMOVE THIS COMMENT/, c.body_str)
     end
 
     c1.on_failure do|c,rc|
@@ -484,5 +484,4 @@ class TestCurbCurlMulti < Test::Unit::TestCase
   def setup
     server_setup
   end
-
 end


### PR DESCRIPTION
This attempts to address segfaults when curb is used in multithreaded
environment.

The solution is to move `@requests` handling code to remove unsafe API
calls from C (`st.c` is not thread safe).

More details can be found here: https://bugs.ruby-lang.org/issues/14357

-----------

I spent more time trying to reproduce the segfault reported in https://github.com/taf2/curb/issues/342, but sadly to no success. Anyone willing to test this branch perhaps?