### PR TITLE
fix timeout and timeout_ms to handle floats and negative numbers

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1215,7 +1215,7 @@ static VALUE ruby_curl_easy_timeout_ms_set(VALUE self, VALUE timeout_ms) {
  * Obtain the maximum time in milliseconds that you allow the libcurl transfer
  * operation to take.
  */
-static VALUE ruby_curl_easy_timeout_ms_get(VALUE self, VALUE timeout_ms) {
+static VALUE ruby_curl_easy_timeout_ms_get(VALUE self) {
   ruby_curl_easy *rbce;
   Data_Get_Struct(self, ruby_curl_easy, rbce);
   return LONG2NUM(rbce->timeout_ms);
@@ -2204,13 +2204,8 @@ VALUE ruby_curl_easy_setup(ruby_curl_easy *rbce) {
 
   curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, rbce->unrestricted_auth);
 
-  /* timeouts override each other we cannot blindly set timeout and timeout_ms */
-  if (rbce->timeout && rbce->timeout > 0) {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, rbce->timeout);
-  }
-  if (rbce->timeout_ms && rbce->timeout_ms > 0) {
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, rbce->timeout_ms);
-  }
+  curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, rbce->timeout_ms);
+
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, rbce->connect_timeout);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, rbce->connect_timeout_ms);
   curl_easy_setopt(curl, CURLOPT_DNS_CACHE_TIMEOUT, rbce->dns_cache_timeout);

--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -339,29 +339,69 @@ class TestCurbCurlEasy < Test::Unit::TestCase
     c.max_redirects = nil
     assert_nil c.max_redirects
   end
-  
+
+  def test_timeout_with_floats
+    c = Curl::Easy.new($TEST_URL)
+
+    c.timeout = 1.5
+    assert_equal 1500, c.timeout_ms
+    assert_equal 1.5, c.timeout
+  end
+
+  def test_timeout_with_negative
+    c = Curl::Easy.new($TEST_URL)
+
+    c.timeout = -1.5
+    assert_equal 0, c.timeout
+    assert_equal 0, c.timeout_ms
+
+    c.timeout = -4.8
+    assert_equal 0, c.timeout
+    assert_equal 0, c.timeout_ms
+  end
+
   def test_timeout_01
     c = Curl::Easy.new($TEST_URL)
-    
-    assert_nil c.timeout
-    
+
+    assert_equal 0, c.timeout
+
     c.timeout = 3
     assert_equal 3, c.timeout
-    
-    c.timeout = nil
-    assert_nil c.timeout
+
+    c.timeout = 0
+    assert_equal 0, c.timeout
   end
 
   def test_timeout_ms_01
     c = Curl::Easy.new($TEST_URL)
 
-    assert_nil c.timeout_ms
+    assert_equal 0, c.timeout_ms
 
     c.timeout_ms = 100
     assert_equal 100, c.timeout_ms
 
     c.timeout_ms = nil
-    assert_nil c.timeout_ms
+    assert_equal 0, c.timeout_ms
+  end
+
+  def test_timeout_ms_with_floats
+    c = Curl::Easy.new($TEST_URL)
+
+    c.timeout_ms = 55.5
+    assert_equal 55, c.timeout_ms
+    assert_equal 0.055, c.timeout
+  end
+
+  def test_timeout_ms_with_negative
+    c = Curl::Easy.new($TEST_URL)
+
+    c.timeout_ms = -1.5
+    assert_equal 0, c.timeout
+    assert_equal 0, c.timeout_ms
+
+    c.timeout_ms = -4.8
+    assert_equal 0, c.timeout
+    assert_equal 0, c.timeout_ms
   end
 
   def test_connect_timeout_01


### PR DESCRIPTION
The setter used `CURB_IMMED_SETTER` macro and it casts value to `long`
and loses precision if float was passed. C will round down as part of
the conversion and if it converts to 0 then the IMMED_GETTER will return
nil.

This results in a confusing output described in #355.

This commit deperecates `CURLOPT_TIMEOUT` option and the code will rely
exclusively on `timeout_ms` (and `CURLOPT_TIMEOUT_MS` accordingly).

There are minor user-facing changes:

* timeout and timeout_ms will not return nil anymore
* change of timeout will now also change timeout_ms respectively
* timeout will return numeric rather than fixnum

Otherwise everything should be working as expected.