### PR TITLE
enable builds in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ext/curb_upload.o
 ext/curb_config.h
 pkg/
 ext/mkmf.log
+build/
+vendor/
+.bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'mixlib-shellout'
+gem 'pry'
+
 group 'development', 'test' do
   gem 'rdoc'
   gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,9 +6,15 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.2)
     ffi2-generators (0.1.1)
+    method_source (0.9.0)
     minitest (4.7.5)
+    mixlib-shellout (2.4.0)
     power_assert (1.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rake (12.3.1)
     rdoc (6.0.4)
     rubysl (2.2.0)
@@ -224,6 +230,8 @@ PLATFORMS
 DEPENDENCIES
   curb!
   minitest
+  mixlib-shellout
+  pry
   rake
   rdoc
   rubysl (~> 2.0)

--- a/Gemfile.ruby-2.1
+++ b/Gemfile.ruby-2.1
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec
+
+gem 'mixlib-shellout', '< 2.3'
+gem 'rake', '< 12'
+gem 'test-unit'

--- a/Gemfile.ruby-2.1.lock
+++ b/Gemfile.ruby-2.1.lock
@@ -1,0 +1,25 @@
+PATH
+  remote: .
+  specs:
+    curb (0.9.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    mixlib-shellout (2.2.7)
+    power_assert (1.1.3)
+    rake (11.3.0)
+    test-unit (3.2.8)
+      power_assert
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  curb!
+  mixlib-shellout (< 2.3)
+  rake (< 12)
+  test-unit
+
+BUNDLED WITH
+   1.15.1

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,22 @@ CLOBBER.include '**/*.log'
 CLOBBER.include '**/Makefile'
 CLOBBER.include '**/extconf.h'
 
+# Not available for really old rubies, but that's ok.
+begin
+  require 'pry'
+rescue LoadError
+  puts "Failed to load pry."
+end
+
+# Load support ruby and rake files (in this order)
+Dir.glob('tasks/*.rb').each { |r| load r}
+Dir.glob('tasks/*.rake').each { |r| load r}
+
+desc 'Print Ruby major version (ie "2_5")'
+task :ruby_version do
+  print current_ruby_major
+end
+
 def announce(msg='')
   $stderr.puts msg
 end
@@ -43,12 +59,11 @@ end
 make_program = (/mswin/ =~ RUBY_PLATFORM) ? 'nmake' : 'make'
 MAKECMD = ENV['MAKE_CMD'] || make_program
 MAKEOPTS = ENV['MAKE_OPTS'] || ''
-
 CURB_SO = "ext/curb_core.#{(defined?(RbConfig) ? RbConfig : Config)::MAKEFILE_CONFIG['DLEXT']}"
 
 file 'ext/Makefile' => 'ext/extconf.rb' do
   Dir.chdir('ext') do
-    ruby "extconf.rb #{ENV['EXTCONF_OPTS']}"
+    shell('ruby', 'extconf.rb', ENV['EXTCONF_OPTS'].to_s, live_stdout: STDOUT)
   end
 end
 

--- a/tasks/docker.rake
+++ b/tasks/docker.rake
@@ -1,0 +1,292 @@
+# ==== About Docker
+#
+# Docker needs to be installed and support mounting host volumes for tasks to work as expected.
+#
+# macOS and Windows may require additonal configuration that is not covered here. Refer to the
+# official documentation:
+#
+# * https://docs.docker.com/docker-for-mac/#file-sharing
+# * https://docs.docker.com/docker-for-windows/#shared-drives
+#
+# Additionally, on Linux, having enabled and configured user namespaces is recommended to maintain
+# file permissions.  Not having user-ns will make all new files belonging to root and some tasks may
+# stop working outside of docker environment.
+#
+# See the oficial docummentation how to enable user-ns:
+#
+# https://docs.docker.com/engine/security/userns-remap/
+#
+# WARNING: Enabling user namespaces will have global impact and some containers/images will not work
+#          in this configuration.  Do read the documentation carefully.
+#
+#          Disabling user namespaces will restore the original docker behavior and fix any errors
+#          related to user-ns.
+#
+# ==== Summary
+#
+# This namespace provides Rake tasks to manage development environment in docker.
+#
+# With minimal requirements it allows to run all tests across all supported rubies and provides a
+# real time feedback.
+#
+# Start with "docker:environment" task (can be ran multiple times) and then run "docker:test".
+#
+# Use 'docker:list_rubies' task to list supported ruby images.
+#
+# Use 'docker:test' task to run a test suite in docker.
+#
+# To run tests on different ruby set DOCKER_RUBY_IMAGE environment variable to a supported ruby.
+#
+# This has been tested in Linux with Docker v18.06, with user namespaces enabed and running in
+# non-privileged mode.
+namespace :docker do
+  desc "Run the test suite in docker environment (#{Docker.ruby_image})"
+  task :test => :recompile do
+    run_in_docker(Docker.ruby_image, 'rake', 'tu', :live_stdout => STDOUT).error!
+  end
+
+  desc "Run the test suite against all rubies"
+  task :test_all do
+    Docker::DOCKER_IMAGES.keys.each do |image_name|
+      ENV['DOCKER_RUBY_IMAGE'] = image_name
+      Rake::Task['docker:recompile'].reenable
+      invoke_and_reenable('docker:test')
+    end
+  end
+
+  desc 'List supported ruby images (for use as DOCKER_RUBY_IMAGE env)'
+  task :list_rubies do
+    puts "Supported images:"
+    Docker::DOCKER_IMAGES.keys.each do |image_name|
+      puts "  #{image_name}"
+    end
+  end
+
+  # This task automates the environment configuration for developing Curb in docker.
+  #
+  # It pulls necessary images, configures volumes, networks etc...
+  #
+  # It also collects the following diagnostic information:
+  #
+  # * docker binary client & server version (docker system info)
+  # * docker network the containers will use (docker network inspect <network>)
+  # * all named docker volumes (docker volume inspect <volume>)
+  # * all pulled docker images (docker image inspect <image>)
+  # * ruby environment of each container (bundle env)
+  # * curl version (curl -V)
+  # * last 3 commits info (without diffs)
+  #
+  # All the collected data is stored in 'build/docker/*'.
+  desc 'Docker docker environment for developing Curb.'
+  task :environment => Docker::BUILD_DIRECTORIES do
+    Rake::Task['build/docker/docker.json'].invoke
+    Rake::Task['build/docker/network.json'].invoke
+    Rake::Task['build/docker/git_curb_info.txt'].invoke
+
+    Docker::DOCKER_IMAGES.each do |name, conf|
+      # create all named volumes
+      conf[:volumes].each { |vol| Rake::Task[vol[:filepath]].invoke }
+
+      Rake::Task[conf[:filepath]].invoke
+      Rake::Task[conf[:bundle_env_filepath]].invoke if conf[:bundle_env_filepath]
+      Rake::Task[conf[:curl_filepath]].invoke       if conf[:curl_filepath]
+    end
+  end
+
+  # Tasks listed below should be considered private and not invoked directly. These tasks do not
+  # have "desc" to make Rake not list them.
+  #
+  # Rake will ignore the "private" statement, it's added here to show the intention.
+  private
+
+  file 'build/docker/_compiled_to_ruby.txt' do
+    Rake::Task['docker:recompile'].invoke
+  end
+
+  file 'build/docker/git_curb_info.txt' do
+    Rake::Task['docker:docker_git_curb_info'].invoke
+  end
+
+  file 'build/docker/docker.json' do
+    Rake::Task['docker:docker_binary'].invoke
+  end
+
+  file 'build/docker/network.json' do
+    Rake::Task['docker:docker_network'].invoke
+  end
+
+  # This section generates file tasks based on the configuration (see 'tasks/rake_helpers.rb').
+  #
+  # This code is being evaluated (loaded) early in the Rakefile, before any task is executed.
+  # By the time Rake executes a task the "file" resources defined here are available.
+  Docker::BUILD_DIRECTORIES.each { |dir| directory(dir) }
+  Docker::DOCKER_IMAGES.each do |full_name, conf|
+    file conf[:filepath] do
+      invoke_and_reenable('docker:docker_pull', full_name)
+    end
+
+    file conf[:bundle_env_filepath] do
+      invoke_and_reenable('docker:bundle_install', full_name)
+    end if conf[:bundle_env_filepath]
+
+    (conf[:volumes] || []).each do |vol_conf|
+      file vol_conf[:filepath] do
+        invoke_and_reenable('docker:docker_volume', vol_conf[:name], vol_conf[:filepath])
+      end
+    end
+
+    file conf[:curl_filepath] do
+      invoke_and_reenable('docker:docker_curl', full_name)
+    end if conf[:curl_filepath]
+  end
+
+  #################
+  #
+  # Tasks defined below perform actual work and should not be invoked individually.
+  #
+  # These tasks are implementation detail and can change at any time without warning.
+  #
+  # This is the heart of docker.rake
+  ##################
+
+  # This task is a direct dependency of 'docker:test'. It has 2 purposes:
+  #
+  # * detect if curb has been compiled against current ruby
+  # * recompile only if needed
+  #
+  # To successfuly recompile we need to clobber first, otherwise the built-in 'compile' task will
+  # do nothing because it can't detect changes to the system libraries.
+  #
+  # This task triggers full recompilation on ruby version change, but when only source files are
+  # changed it does nothing. In such case the default 'compile' target will run recompilation on
+  # changed files only.
+  task :recompile do
+    # Find out what ruby version are we running in docker
+    cmd_ruby_v_docker = run_in_docker(Docker.ruby_image, 'rake', 'ruby_version')
+    cmd_ruby_v_docker.error!
+    ruby_v_docker = cmd_ruby_v_docker.stdout
+
+    # Check what Ruby version was Curb compiled against and set it to UNKNOWN if the file doesn't
+    # exist to trigger recompilation (we can't know if it was compiled with correct Ruby).
+    ruby_v_filepath = 'build/docker/_compiled_to_ruby.txt'
+    ruby_v_file = File.exists?(ruby_v_filepath) ? File.read(ruby_v_filepath) : 'UNKNOWN'
+
+    if ruby_v_file != ruby_v_docker
+      run_in_docker(Docker.ruby_image, 'rake', 'clobber').error!
+      run_in_docker(Docker.ruby_image, 'rake', 'compile', live_stdout: nil).error!
+    end
+
+    File.write(ruby_v_filepath, ruby_v_docker)
+  end
+
+  # Creates persistent named volumes for containers to store gems installed by bundler.
+  #
+  # Docker containers have ephermal file system and can't persist anything. Any changes to the disk
+  # will be deleted when the container stops. As a result we'd need to do a fresh 'bundle install'
+  # each time we want to run tests.
+  #
+  # To avoid 'bundle install' completely we will mount a persistent volume to '/usr/local/bundle'.
+  task :docker_volume, [:volume_name, :filepath] do |_, args|
+    abort('volume_name argument is required.') unless args.volume_name
+    abort('filepath argument is required.') unless args.filepath
+
+    # This should never fail, even if the volume exists docker return success, but if it does for
+    # whatever reason we can't do anything about it so we will just explode.
+    create_cmd = shell('docker', 'volume', 'create', args.volume_name)
+    abort('failed to create docker volume') if create_cmd.error?
+
+    # This could fail if the volume (for any reason) does not exist.
+    inspect_cmd = shell('docker', 'volume', 'inspect', args.volume_name)
+    inspect_cmd.error!
+
+    File.write(args.filepath, inspect_cmd.stdout)
+  end
+
+  # Run bundle install on the container and dump bundle env to file. The gems will be installed to
+  # the shared volume for later reuse.
+  #
+  # Each image has it's own volume and different ruby versions are completely isolated.
+  task :bundle_install, [:name] do |_, args|
+    config = Docker::DOCKER_IMAGES[args.name]
+
+    bundle_install = run_in_docker(args.name, 'bundle', 'install')
+    bundle_install.error!
+
+    bundle_env = run_in_docker(args.name, 'bundle', 'env')
+    bundle_env.error!
+
+    File.write(config[:bundle_env_filepath], bundle_env.stdout)
+  end
+
+  # Pull a docker image from Dockerhub.
+  #
+  # This will pull up-to-date images, it's common otherwise to have local outdated images in the
+  # cache. We always want to work on the most recent versions.
+  task :docker_pull, [:name] do |_, args|
+    conf = Docker::DOCKER_IMAGES[args.name]
+
+    pull_cmd = shell('docker', 'pull', "#{conf[:name]}:#{conf[:tag]}")
+    abort('docker pull failed.') if pull_cmd.error?
+
+    inspect_cmd = shell('docker', 'image', 'inspect', "#{conf[:name]}:#{conf[:tag]}")
+    inspect_cmd.error!
+
+    File.write(conf[:filepath], inspect_cmd.stdout)
+  end
+
+  # Make sure the docker binary is available.
+  task :docker_binary do
+    cmd = shell('docker', 'system', 'info', '--format', '{{json .}}')
+    if cmd.error?
+      abort('docker binary not found on the system. Make sure docker is installed.')
+    end
+
+    File.write('build/docker/docker.json', cmd.stdout)
+  end
+
+  # Create docker network `curb`.
+  #
+  # Using a named network will allow us to run supporting services in docker. It's not in active
+  # use currently and it's intended for the future.
+  #
+  # The intention is to allow easy testing against different configurations with little manual
+  # setup.
+  #
+  # Some possible examples:
+  #
+  # * test with nginx or apache
+  # * test different protocols CURL supports (ie SMTP)
+  # * test against backend application written in any language
+  #
+  # With initial setup in place, and even if the feature is not used in the codebase it's handy for
+  # local development.
+  task :docker_network do
+    shell('docker', 'network', 'create', 'curb')
+
+    inspect_cmd = shell('docker', 'network', 'inspect', 'curb')
+    inspect_cmd.error!
+
+    File.write('build/docker/network.json', inspect_cmd.stdout)
+  end
+
+  # Make sure curl is available
+  task :docker_curl, [:full_name] do |_, args|
+    conf = Docker::DOCKER_IMAGES[args.full_name]
+
+    curl_info = run_in_docker(args.full_name, 'curl', '-V')
+    curl_info.error!
+
+    File.write(conf[:curl_filepath], curl_info.stdout)
+  end
+
+  # Grab last 3 commits and save info to the file.
+  #
+  # '--no-pager' is required, otherwise git would block waiting on user input when the commit is
+  # too long to display on one screen. Since we don't connect stdin it would hang indefinitely.
+  task :docker_git_curb_info do
+    git_cmd = run_in_docker(Docker.ruby_image, 'git', '--no-pager', 'log', '--graph', '-n', '3', '--no-color')
+    git_cmd.error!
+
+    File.write('build/docker/git_curb_info.txt', git_cmd.stdout)
+  end
+end

--- a/tasks/rake_helpers.rb
+++ b/tasks/rake_helpers.rb
@@ -1,0 +1,240 @@
+begin
+  require 'mixlib/shellout'
+rescue LoadError
+  puts "Failed to load mixlib/shellout."
+end
+
+module Curb
+  module RakeHelpers
+
+    # This module is being required in the top level Rakefile and it provides all-around helpers.
+    module DSL
+
+      # Invoke a Rake task by name and enable it again after completion.
+      #
+      # Rake tries to be smarter than Make when it comes to dependency graph resolution and it will
+      # invoke any task only once, even if it's called multiple times with different parameters.
+      #
+      # It's not a bug, it's how Rake is designed to work.
+      #
+      # To workaround this limitation a wrapper method will invoke and then re-enable the task
+      # afterwards. No exception handling is necessary as the Rake will just abort everything.
+      def invoke_and_reenable(task_name, *args)
+        rake_task = Rake::Task[task_name]
+        rake_task.invoke(*args)
+        rake_task.reenable # allow the task to be executed again
+        rake_task
+      end
+
+      # Returns the current ruby major version.
+      #
+      # Ruby uses the following version schema:
+      #
+      #   <MAJOR>.<MINOR>.<TEENY>
+      #
+      # Ruby maintains API compatibility on <TEENY> level and change to <MINOR> means breaking
+      # changes.
+      #
+      # When compiling sources we will persist the information about ruby version used and when it
+      # changes it's a signal to recompile.
+      def current_ruby_major
+        RUBY_VERSION.match(/(\d).(\d).\d/)[1..2].join('_') # => 2_5
+      end
+
+      # Helper method for shelling out.
+      #
+      # It's easier than Rake's 'sh' and it's backed by Mixlib::Shellout if available with fallback
+      # to pure ruby implementation compatible down to Ruby 1.8.
+      def shell(*args)
+        mix_options = args.last.is_a?(Hash) ? args.pop : {}
+
+        puts "> #{args.join(' ')}"
+
+        _shell_wrapper(*args, mix_options).run_command
+      end
+
+      def run_in_docker(*args)
+        Docker.run_in_docker(*args)
+      end
+
+      private
+
+      # Mixlib won't be available on every ruby we support. This handles selecting appropriate
+      # backed for the command.
+      def _shell_wrapper(*args)
+        defined?(Mixlib::ShellOut) ? Mixlib::ShellOut.new(*args) : ShellWrapper.new(*args)
+      end
+    end
+
+    # This module encapsulates configuration and helper methods to interact with docker.
+    module Docker
+      DEFAULT_DOCKER_IMAGE = 'ruby:2.5'
+      BUILD_DIRECTORIES = %w(build/docker)
+
+      DOCKER_VOLUMES = {
+        'ruby:2.0' => [ { :name => 'curb_ruby_2_0', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_0.json' } ],
+        'ruby:2.1' => [ { :name => 'curb_ruby_2_1', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_1.json' } ],
+        'ruby:2.2' => [ { :name => 'curb_ruby_2_2', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_2.json' } ],
+        'ruby:2.3' => [ { :name => 'curb_ruby_2_3', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_3.json' } ],
+        'ruby:2.4' => [ { :name => 'curb_ruby_2_4', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_4.json' } ],
+        'ruby:2.5' => [ { :name => 'curb_ruby_2_5', :mount_path => '/usr/local/bundle', :filepath => 'build/docker/volume_ruby_2_5.json' } ],
+      }
+
+      DOCKER_IMAGES = {
+        'ruby:2.0'     => { :name => 'ruby',  :tag => '2.0',
+                            :filepath => 'build/docker/image_ruby_2_0.json',
+                            :gemfile => 'Gemfile.ruby-2.1',
+                            :curl_filepath => 'build/docker/curl_ruby_2_0.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_0.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.0'] },
+        'ruby:2.1'     => { :name => 'ruby',  :tag => '2.1',
+                            :gemfile => 'Gemfile.ruby-2.1',
+                            :filepath => 'build/docker/image_ruby_2_1.json',
+                            :curl_filepath => 'build/docker/curl_ruby_2_1.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_1.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.1'] },
+        'ruby:2.2'     => { :name => 'ruby',  :tag => '2.2',
+                            :filepath => 'build/docker/image_ruby_2_2.json',
+                            :curl_filepath => 'build/docker/curl_ruby_2_2.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_2.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.2'] },
+        'ruby:2.3'     => { :name => 'ruby',  :tag => '2.3',
+                            :filepath => 'build/docker/image_ruby_2_3.json',
+                            :curl_filepath => 'build/docker/curl_ruby_2_3.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_3.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.3'] },
+        'ruby:2.4'     => { :name => 'ruby',  :tag => '2.4',
+                            :filepath => 'build/docker/image_ruby_2_4.json',
+                            :curl_filepath => 'build/docker/curl_ruby_2_4.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_4.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.4'] },
+        'ruby:2.5'     => { :name => 'ruby',  :tag => '2.5',
+                            :filepath => 'build/docker/image_ruby_2_5.json',
+                            :curl_filepath => 'build/docker/curl_ruby_2_5.txt',
+                            :bundle_env_filepath => 'build/docker/bundle_env_ruby_2_5.md',
+                            :volumes => DOCKER_VOLUMES['ruby:2.5'] },
+      }
+
+      # Returns current docker image name with tag for other Rake tasks to use.
+      #
+      # Task 'docker:test_all' overwrites the ENV to run a test suite for every configuration, but
+      # otherwise it's not overridden anywhere.
+      #
+      # 'docker:test' uses this to select appropriate image to test on.
+      #
+      # Example:
+      #
+      #   DOCKER_RUBY_IMAGE=ruby:2.2 rake docker:test # run a test suite on Ruby 2.2
+      #
+      def self.ruby_image
+        ENV['DOCKER_RUBY_IMAGE'] || DEFAULT_DOCKER_IMAGE
+      end
+
+      # Execute a command in docker container.
+      #
+      # If the last argument is a Hash it will be used as options for the Ruby shell and not to
+      # passed to docker as part of the command.
+      #
+      # See Mixlib::ShellOut documentation for supported options.
+      # See Curb::RakeHelpers::ShellWrapper (defined in 'tasks/utils.rb') for supported options.
+      #
+      # The command will be passed to the Mixlib library if available, otherwise (old rubies) it
+      # will be passed through ShellWrapper.
+      #
+      # If this method is invoked from inside the docker container it will raise an exception. We
+      # will not support running docker in docker.
+      #
+      # Given an example call:
+      #
+      #   Curb::Docker.run_in_docker('ruby:2.5', 'rake', 'recompile')
+      #
+      # It's being translated to the following shell command:
+      #
+      #   docker run --rm -t -w /code -v $PWD/curb-clean:/code
+      #              --mount type=volume,source=curb_ruby_2_5,target=/usr/local/bundle
+      #              --network curb
+      #              ruby:2.5 rake compile
+      #
+      def self.run_in_docker(image_name, *cmd)
+        conf = DOCKER_IMAGES[image_name]
+
+        # The docker-in-docker detection is as simple as checking existence of '/.dockerenv' file.
+        # '.dockerenv' and '.dockerinit' have been historically used with the LXC execution driver,
+        # but it has been completely removed from docker in version 1.10.0 and the files are no
+        # longer used for anything, yet remain widely used.
+        #
+        # Official ruby images ship with an empty '.dockerenv' file.
+        docker_in_docker = File.exists?('/.dockerenv')
+        abort("Can't run docker inside docker") if docker_in_docker
+
+        # If last argument of cmd is a hash do not pass it to docker, but pass it to shell.
+        shell_options =  cmd.last.is_a?(Hash) ? cmd.pop : {}
+
+        # Setup mount points for named volumes.
+        #
+        # These volumes are used to persist gems installed with 'bundle install' across runs.
+        #
+        # As of version 17.06 standalone containers support '--mount' flag that is almost
+        # equivalent to '-v'.
+        #
+        # When '-v' flag is used to mount a host volume and the local path does not exist it will
+        # create an empty directory and then mount it.
+        #
+        # When '--mount' flag is used with a non-existent path it will raise an error.
+        #
+        # '--mount' is more verbose than '-v', but it's more explicit, easier to understand,
+        # and it's recommended over '-v' in the documentation:
+        #
+        #   New users should use the --mount syntax. Experienced users may be more familiar
+        #   with the -v or --volume syntax, but are encouraged to use --mount, because research has
+        #   shown it to be easier to use.
+        #
+        # Source: https://docs.docker.com/storage/bind-mounts/
+        volumes = DOCKER_VOLUMES[image_name].map do |conf|
+          ['--mount', "type=volume,source=#{conf[:name]},target=#{conf[:mount_path]}"]
+        end
+
+        # Inject custom gemfiles over the original ones.
+        #
+        # Bundler supports BUNDLE_GEMFILE environment variable that points to non-standard Gemfile,
+        # but it doesn't work reliably across rubies and compilation crashes on 2.1.
+        #
+        # This will +shadow+ the original Gemfile and Gemfile.lock with a custom one if defined in
+        # the configuration.
+        #
+        # It will crash if custom Gemfile or Gemfile.lock does not exist.
+        if conf[:gemfile]
+          volumes << ['--mount', "type=bind,source=#{Dir.pwd}/#{conf[:gemfile]},target=/code/Gemfile"]
+          volumes << ['--mount', "type=bind,source=#{Dir.pwd}/#{conf[:gemfile]}.lock,target=/code/Gemfile.lock"]
+        end
+
+        # Mount project directory to '/code'. Any changes made the local files will be reflected
+        # in the container.
+        #
+        # It allows 'rake docker:test' to see the changes instantly and enables real-time feedback
+        # loop for developer's convenience.
+        volumes << ['--mount', "type=bind,source=#{Dir.pwd},target=/code"]
+
+        args = [ 'docker',
+                 'run',
+                 '--rm',
+                 '-t', # make docker color the output :)
+                 '-w', '/code',
+                 '--network', 'curb',
+                 volumes,
+                 image_name,
+                 cmd].flatten!
+
+         shell(*args, shell_options)
+      end
+    end
+  end
+end
+
+# Because the file is loaded rather than required this will be evaluated by Ruby
+# and the DSL will be extended automatically.
+include Curb::RakeHelpers::DSL
+
+# Handy shortcut
+abort("FATAL: Docker constant already loaded.") if defined?(Docker)
+Docker = Curb::RakeHelpers::Docker

--- a/tasks/utils.rb
+++ b/tasks/utils.rb
@@ -1,0 +1,58 @@
+require 'open3'
+
+module Curb
+  module RakeHelpers
+    # A simple shell wrapper using stdlib open3. It implements very basic set of methods to
+    # mimic MixLib.
+    #
+    # It's used for old rubies where MixLib is not available.
+    class ShellWrapper
+      def initialize(*args)
+        @options = args.last.is_a?(Hash) ? args.pop : {}
+        @cmd = args
+        @live_stream = @options.delete(:live_stdout)
+        @stdout = ''
+        @stderr = ''
+      end
+
+
+      def run_command
+        wait_thr = nil
+        Open3.popen3(*@cmd) do |stdin, stdout, stderr, thr|
+          stdin.close
+          wait_thr = thr
+
+          while line = stdout.gets do
+            @stdout << line
+            @live_stream.puts(line) if @live_stream
+          end
+
+          while line = stderr.gets do
+            @stderr << line
+            puts line
+          end
+        end
+
+        @exit_code = wait_thr.value.exitstatus
+        @error = !wait_thr.value.success?
+        self
+      end
+
+      def stderr
+        @stderr
+      end
+
+      def stdout
+        @stdout
+      end
+
+      def error!
+        fail "Command failed with exit-code #{@exit_code}" if @error
+      end
+
+      def error?
+        !!@error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a set of rake tasks to enable use of docker for
development.

Task `rake docker:environment` makes necessary configuration and `rake
docker:test_all` will then run tests on all supported rubies.

Currently supported rubies are 2.0, 2.1, 2.2, 2.3, 2.4, 2.5.

There were significant changes in ruby 2.2 and many gems dropped
support for older versions so they can't be upgraded or are currently
broken.

Curb has minimal set of ruby dependencies and this isn't too much
of an issue for the gem itself, but it holds us back when it comes to
the build system maintenance.

Maintaining backward compatibility requires either a lot of patience to
wait and debug error messages reported by Travis or complex local setup.

Introduction of docker aims to solve this problem by providing
convenient command to run curb against any supported ruby version with
minimal setup.

Shell access makes debugging much easier and after initial bootstrap the
feedback is provided in real time.

Docker also provides isolated environment to debug issues much easier.

This commit does build on top of existing tasks and does not change the
current process, instead it offers an alternative.

Because the setup hasn't been battle-tested (single user so far) it
isn't mentioned in the README. For this reason further improvements may
be necessary.

It's fairly easy to break the setup when using both docker and local
environments at the same time:

* some files may become owned by root if user-ns are not enabled
* Gemfile updates are not automated
* local compilation may break docker setup

Usually, to fix the docker setup, all it takes is to remove the `build`
directory and re-run `rake docker:environment` - it will recreate
everything from scratch and it's safe to run (it doesn't delete any
files whatsoever).

'rake docker:test' will run the tests on 'ruby:2.5' by default, but it's
possible to change ruby with env variable:

DOCKER_RUBY_IMAGE=ruby:2.2 rake docker:test

'build/docker' directory contains files with diagnostic information.
These files are created by the `docker` family Rake tasks and are used
to orchestrate Rake execution. Those are all text files.