### PR TITLE
guard use of CURLOPT_RESOLVE in #if HAVE_CURLOPT_RESOLVE

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -2346,6 +2346,7 @@ VALUE ruby_curl_easy_setup(ruby_curl_easy *rbce) {
     }
   }
 
+#if HAVE_CURLOPT_RESOLVE
   /* Setup resolve list if necessary */
   if (!rb_easy_nil("resolve")) {
     if (rb_easy_type_check("resolve", T_ARRAY)) {
@@ -2357,6 +2358,7 @@ VALUE ruby_curl_easy_setup(ruby_curl_easy *rbce) {
       curl_easy_setopt(curl, CURLOPT_RESOLVE, *rslv);
     }
   }
+#endif
 
   return Qnil;
 }


### PR DESCRIPTION
curb checks for CURLOPT_RESOLVE properly but doesn't guard its usage everywhere.

This fixes building curb 0.9.x on CentOS 6 (with curl 7.19.x), which for us failed with the following:

```
current directory: /home/jokwan/.gem/ruby/2.3.0/gems/curb-0.9.6/ext
make "DESTDIR="
compiling curb.c
compiling curb_easy.c
curb_easy.c: In function ‘ruby_curl_easy_setup’:
curb_easy.c:2357: error: ‘CURLOPT_RESOLVE’ undeclared (first use in this function)
curb_easy.c:2357: error: (Each undeclared identifier is reported only once
curb_easy.c:2357: error: for each function it appears in.)
curb_easy.c:2357: warning: type defaults to ‘int’ in declaration of ‘_curl_opt’
make: *** [curb_easy.o] Error 1

make failed, exit code 2
```