### PR TITLE
fixes to make curb work on ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
 matrix:
   allow_failures:
    - rvm: rbx-3
+   - rvm: ruby-head
   fast_finish: true
 cache: bundler
 before_install:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.7)
+    curb (0.9.8)
 
 GEM
   remote: https://rubygems.org/
@@ -239,4 +239,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/Gemfile.ruby-1.8.lock
+++ b/Gemfile.ruby-1.8.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.7)
+    curb (0.9.8)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby-1.8.lock
+++ b/Gemfile.ruby-1.8.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.6)
+    curb (0.9.7)
 
 GEM
   remote: https://rubygems.org/
@@ -16,6 +16,3 @@ DEPENDENCIES
   curb!
   rake (< 12)
   test-unit (< 3)
-
-BUNDLED WITH
-   1.15.4

--- a/Gemfile.ruby-2.1.lock
+++ b/Gemfile.ruby-2.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.6)
+    curb (0.9.7)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.ruby-2.1.lock
+++ b/Gemfile.ruby-2.1.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.7)
+    curb (0.9.8)
 
 GEM
   remote: https://rubygems.org/

--- a/ext/curb.h
+++ b/ext/curb.h
@@ -41,6 +41,11 @@
   #define RHASH_SIZE(hash) RHASH(hash)->tbl->num_entries
 #endif
 
+// ruby 1.8 does not provide the macro
+#ifndef DBL2NUM
+  #define DBL2NUM(dbl) rb_float_new(dbl)
+#endif
+
 extern VALUE mCurl;
 
 extern void Init_curb_core();

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -18,6 +18,8 @@ elsif !have_library('curl') or !have_header('curl/curl.h')
   fail <<-EOM
   Can't find libcurl or curl/curl.h
 
+  Make sure development libs (ie libcurl4-openssl-dev) are installed on the system.
+
   Try passing --with-curl-dir or --with-curl-lib and --with-curl-include
   options to extconf.
   EOM

--- a/tasks/docker.rake
+++ b/tasks/docker.rake
@@ -206,11 +206,11 @@ exec "$@"
 
     # This should never fail, even if the volume exists docker return success, but if it does for
     # whatever reason we can't do anything about it so we will just explode.
-    create_cmd = shell('docker', 'volume', 'create', args.volume_name)
+    create_cmd = shell(['docker', 'volume', 'create', args.volume_name])
     abort('failed to create docker volume') if create_cmd.error?
 
     # This could fail if the volume (for any reason) does not exist.
-    inspect_cmd = shell('docker', 'volume', 'inspect', args.volume_name)
+    inspect_cmd = shell(['docker', 'volume', 'inspect', args.volume_name])
     inspect_cmd.error!
 
     File.write(args.filepath, inspect_cmd.stdout)
@@ -239,10 +239,10 @@ exec "$@"
   task :docker_pull, [:name] do |_, args|
     conf = Docker::DOCKER_IMAGES[args.name]
 
-    pull_cmd = shell('docker', 'pull', "#{conf[:name]}:#{conf[:tag]}")
+    pull_cmd = shell(['docker', 'pull', "#{conf[:name]}:#{conf[:tag]}"])
     abort('docker pull failed.') if pull_cmd.error?
 
-    inspect_cmd = shell('docker', 'image', 'inspect', "#{conf[:name]}:#{conf[:tag]}")
+    inspect_cmd = shell(['docker', 'image', 'inspect', "#{conf[:name]}:#{conf[:tag]}"])
     inspect_cmd.error!
 
     File.write(conf[:filepath], inspect_cmd.stdout)
@@ -250,7 +250,7 @@ exec "$@"
 
   # Make sure the docker binary is available.
   task :docker_binary do
-    cmd = shell('docker', 'system', 'info', '--format', '{{json .}}')
+    cmd = shell(['docker', 'system', 'info', '--format', '{{json .}}'])
     if cmd.error?
       abort('docker binary not found on the system. Make sure docker is installed.')
     end
@@ -275,9 +275,9 @@ exec "$@"
   # With initial setup in place, and even if the feature is not used in the codebase it's handy for
   # local development.
   task :docker_network do
-    shell('docker', 'network', 'create', 'curb')
+    shell(['docker', 'network', 'create', 'curb'])
 
-    inspect_cmd = shell('docker', 'network', 'inspect', 'curb')
+    inspect_cmd = shell(['docker', 'network', 'inspect', 'curb'])
     inspect_cmd.error!
 
     File.write('build/docker/network.json', inspect_cmd.stdout)

--- a/tasks/docker.rake
+++ b/tasks/docker.rake
@@ -42,7 +42,7 @@
 namespace :docker do
   desc "Run the test suite in docker environment (#{Docker.ruby_image})"
   task :test => :recompile do
-    run_in_docker(Docker.ruby_image, 'rake', 'tu', { :live_stdout => STDOUT }).error!
+    run_in_docker(Docker.ruby_image, 'bundle', 'exec', 'rake', 'tu', { :live_stdout => STDOUT }).error!
   end
 
   desc "Run the test suite against all rubies"


### PR DESCRIPTION
Before Ruby 1.8 was removed from Travis it was failing tests related to
outdated lockfile as a result of new curb release.

I had to prepare a Docker environment with Ruby 1.8 to update lockfile
correctly. On top of that this P/R does:

* Rakefile & friends general ruby syntax fixes
  - splat operator is not available in Ruby 1.8
  - new and compact hash syntax is not available in Ruby 1.8
  - popen3 does not yield wait thread in Ruby 1.8
* macro DBL2NUM has been defined
  - not available in Ruby 1.8

There are no official images for Ruby 1.8 and I had to chose
something... Phusion images used to be reliable.

Ruby 1.8 image comes without libcurl development libraries and I decided
to override an entrypoint and install it on demand. It's slow, but it is
enough to check if curb still works on Ruby 1.8.