### PR TITLE
Update homepage in gemspec [ci skip]

### DIFF
--- a/curb.gemspec
+++ b/curb.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   #### Documentation and testing.
   s.has_rdoc = true
-  s.homepage = 'http://curb.rubyforge.org/'
+  s.homepage = 'https://github.com/taf2/curb'
   s.rdoc_options = ['--main', 'README.markdown']
 
   

--- a/lib/curb.gemspec.erb
+++ b/lib/curb.gemspec.erb
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   #### Documentation and testing.
   s.has_rdoc = true
-  s.homepage = 'http://curb.rubyforge.org/'
+  s.homepage = 'https://github.com/taf2/curb'
   s.rdoc_options = ['--main', 'README.markdown']
 
   <% if ENV['BINARY_PACKAGE'] %>


### PR DESCRIPTION
Updating this URL so that the link on rubygems will no longer be a dead link after the next version of this gem is cut.