### PR TITLE
Autoclose close

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,7 @@
 # Change Log
- ### Fixes
-  * Fix build with curl 7.62.0
- ### Enhancements
- ### Breaking Changes
-  * Possibly breaking change with request handling, reduces C (lines of code) and might resolve segfault when mixing curb with ruby timeout
  ## 0.9.8
  ### Fixes
+  * Fix build with curl 7.62.0
  * Fix build with curl 7.62.0
  * Support building against ruby 1.8 to help people migrate to the future and beyond
  ### Enhancements
@@ -13,6 +9,7 @@
  * Add SOCKS5_HOSTNAME support.
  * Addes Curl::Multi.autoclose and Curl::Multi#close to improve connection handling. In past releases connection clean up only ever happens when GC runs.  Now in this release you can explicitly control connections via multi.close or have it always close your connections with Curl::Multi.autoclose=true.
  ### Breaking Changes
+ * Possibly breaking change with request handling, reduces C (lines of code) and might resolve segfault when mixing curb with ruby timeout
  * Timeout change is possibly breaking for anyone who expected 0.9 to == 0 or infinity
  ## 0.9.7
  ### Breaking Changes

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
  ### Enhancements
  * Improve timeout= to allow Floating point values automatically switch to timeout_ms
  * Add SOCKS5_HOSTNAME support.
+ * Addes Curl::Multi.autoclose and Curl::Multi#close to improve connection handling. In past releases connection clean up only ever happens when GC runs.  Now in this release you can explicitly control connections via multi.close or have it always close your connections with Curl::Multi.autoclose=true.
  ### Breaking Changes
  * Timeout change is possibly breaking for anyone who expected 0.9 to == 0 or infinity
  ## 0.9.7

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,6 @@
 # Change Log
  ## 0.9.8
  ### Fixes
-  * Fix build with curl 7.62.0
  * Fix build with curl 7.62.0
  * Support building against ruby 1.8 to help people migrate to the future and beyond
  ### Enhancements

--- a/ext/curb.h
+++ b/ext/curb.h
@@ -20,11 +20,11 @@
 #include "curb_macros.h"
 
 // These should be managed from the Rake 'release' task.
-#define CURB_VERSION   "0.9.7"
-#define CURB_VER_NUM   907
+#define CURB_VERSION   "0.9.8"
+#define CURB_VER_NUM   908
 #define CURB_VER_MAJ   0
 #define CURB_VER_MIN   9
-#define CURB_VER_MIC   7
+#define CURB_VER_MIC   8
 #define CURB_VER_PATCH 0
 
 

--- a/ext/curb_multi.c
+++ b/ext/curb_multi.c
@@ -52,6 +52,16 @@ void curl_multi_free(ruby_curl_multi *rbcm) {
   free(rbcm);
 }
 
+static void ruby_curl_multi_init(ruby_curl_multi *rbcm) {
+  rbcm->handle = curl_multi_init();
+  if (!rbcm->handle) {
+    rb_raise(mCurlErrFailedInit, "Failed to initialize multi handle");
+  }
+
+  rbcm->active = 0;
+  rbcm->running = 0;
+}
+
 /*
  * call-seq:
  *   Curl::Multi.new                                   => #&lt;Curl::Easy...&gt;
@@ -61,13 +71,7 @@ void curl_multi_free(ruby_curl_multi *rbcm) {
 VALUE ruby_curl_multi_new(VALUE klass) {
   ruby_curl_multi *rbcm = ALLOC(ruby_curl_multi);
 
-  rbcm->handle = curl_multi_init();
-  if (!rbcm->handle) {
-    rb_raise(mCurlErrFailedInit, "Failed to initialize multi handle");
-  }
-
-  rbcm->active = 0;
-  rbcm->running = 0;
+  ruby_curl_multi_init(rbcm);
 
   /*
    * The mark routine will be called by the garbage collector during its ``mark'' phase.
@@ -613,7 +617,7 @@ VALUE ruby_curl_multi_close(VALUE self) {
   ruby_curl_multi *rbcm;
   Data_Get_Struct(self, ruby_curl_multi, rbcm);
   curl_multi_cleanup(rbcm->handle);
-  rbcm->handle = NULL;
+  ruby_curl_multi_init(rbcm);
   return self;
 }
 

--- a/ext/curb_multi.c
+++ b/ext/curb_multi.c
@@ -37,6 +37,7 @@ static VALUE idCall;
 VALUE cCurlMulti;
 
 static long cCurlMutiDefaulttimeout = 100; /* milliseconds */
+static char cCurlMutiAutoClose = 0;
 
 static void rb_curl_multi_remove(ruby_curl_multi *rbcm, VALUE easy);
 static void rb_curl_multi_read_info(VALUE self, CURLM *mptr);
@@ -99,6 +100,30 @@ VALUE ruby_curl_multi_set_default_timeout(VALUE klass, VALUE timeout) {
  */
 VALUE ruby_curl_multi_get_default_timeout(VALUE klass) {
   return LONG2NUM(cCurlMutiDefaulttimeout);
+}
+
+/*
+ * call-seq:
+ *   Curl::Multi.autoclose = true => true
+ *
+ * Automatically close open connections after each request. Otherwise, the connection will remain open 
+ * for reuse until the next GC
+ *
+ */
+VALUE ruby_curl_multi_set_autoclose(VALUE klass, VALUE onoff) {
+  cCurlMutiAutoClose = ((onoff == Qtrue) ? 1 : 0);
+  return onoff;
+}
+
+/*
+ * call-seq:
+ *   Curl::Multi.autoclose => true|false
+ *
+ * Get the global default autoclose setting for all Curl::Multi Handles.
+ *
+ */
+VALUE ruby_curl_multi_get_autoclose(VALUE klass) {
+  return cCurlMutiAutoClose == 1 ? Qtrue : Qfalse;
 }
 
 /*
@@ -571,8 +596,27 @@ VALUE ruby_curl_multi_perform(int argc, VALUE *argv, VALUE self) {
 
   rb_curl_multi_read_info( self, rbcm->handle );
   if (block != Qnil) { rb_funcall(block, rb_intern("call"), 1, self);  }
+  if (cCurlMutiAutoClose  == 1) {
+    rb_funcall(self, rb_intern("close"), 0);
+  }
   return Qtrue;
 }
+
+/*
+ * call-seq:
+ *
+ * multi.close
+ * after closing the multi handle all connections will be closed and the handle will no longer be usable
+ *
+ */
+VALUE ruby_curl_multi_close(VALUE self) {
+  ruby_curl_multi *rbcm;
+  Data_Get_Struct(self, ruby_curl_multi, rbcm);
+  curl_multi_cleanup(rbcm->handle);
+  rbcm->handle = NULL;
+  return self;
+}
+
 
 /* =================== INIT LIB =====================*/
 void init_curb_multi() {
@@ -583,10 +627,13 @@ void init_curb_multi() {
   rb_define_singleton_method(cCurlMulti, "new", ruby_curl_multi_new, 0);
   rb_define_singleton_method(cCurlMulti, "default_timeout=", ruby_curl_multi_set_default_timeout, 1);
   rb_define_singleton_method(cCurlMulti, "default_timeout", ruby_curl_multi_get_default_timeout, 0);
+  rb_define_singleton_method(cCurlMulti, "autoclose=", ruby_curl_multi_set_autoclose, 1);
+  rb_define_singleton_method(cCurlMulti, "autoclose", ruby_curl_multi_get_autoclose, 0);
   /* Instance methods */
   rb_define_method(cCurlMulti, "max_connects=", ruby_curl_multi_max_connects, 1);
   rb_define_method(cCurlMulti, "pipeline=", ruby_curl_multi_pipeline, 1);
   rb_define_method(cCurlMulti, "_add", ruby_curl_multi_add, 1);
   rb_define_method(cCurlMulti, "_remove", ruby_curl_multi_remove, 1);
   rb_define_method(cCurlMulti, "perform", ruby_curl_multi_perform, -1);
+  rb_define_method(cCurlMulti, "_close", ruby_curl_multi_close, 0);
 }

--- a/lib/curl/multi.rb
+++ b/lib/curl/multi.rb
@@ -271,5 +271,16 @@ module Curl
       _remove(easy)
       self
     end
+
+    def close
+      requests.values.each {|easy|
+        _remove(easy)
+      }
+      @requests = {}
+      _close
+      self
+    end
+
+
   end
 end

--- a/tests/tc_curl_multi.rb
+++ b/tests/tc_curl_multi.rb
@@ -57,12 +57,16 @@ class TestCurbCurlMulti < Test::Unit::TestCase
     assert did_complete
     after_open = open_fds.call
     assert_equal (after_open - before_open), 0, "auto close the connections"
+  ensure
+    Curl::Multi.autoclose = false # restore default
   end
 
   def test_connection_autoclose
     assert !Curl::Multi.autoclose
     Curl::Multi.autoclose = true
     assert Curl::Multi.autoclose
+  ensure
+    Curl::Multi.autoclose = false # restore default
   end
 
   def test_new_multi_01

--- a/tests/tc_curl_multi.rb
+++ b/tests/tc_curl_multi.rb
@@ -6,6 +6,65 @@ class TestCurbCurlMulti < Test::Unit::TestCase
     ObjectSpace.garbage_collect
   end
 
+  # for https://github.com/taf2/curb/issues/277
+  # must connect to an external
+  def test_connection_keepalive
+    # 0123456 default & reserved RubyVM. It will probably include 7 from Dir.glob
+    open_fds = lambda do 
+      `/usr/sbin/lsof -p #{Process.pid} | egrep "TCP|UDP" | wc -l`.strip.to_i
+    end
+    before_open = open_fds.call
+    assert !Curl::Multi.autoclose
+    multi = Curl::Multi.new
+    multi.max_connects = 1 # limit to 1 connection within the multi handle
+
+    did_complete = false
+    5.times do |n|
+      # NOTE: we use google here because connecting to our TEST_URL as a local host address appears to not register correctly with lsof as a socket... if anyone knows a better way would be great to not have an external dependency here in the test
+      easy = Curl::Easy.new("http://google.com/") do |curl|
+        curl.timeout = 5 # ensure we don't hang for ever connecting to an external host
+        curl.on_complete {
+          did_complete = true
+        }
+      end
+      multi.add(easy)
+    end
+
+    multi.perform
+    assert did_complete
+    after_open = open_fds.call
+    assert_equal (after_open - before_open), 1, "with max connections set to 1 at this point the connection to google should still be open"
+    multi.close
+
+    after_open = open_fds.call
+    assert_equal (after_open - before_open), 0, "after closing the multi handle all connections should be closed"
+
+    Curl::Multi.autoclose = true
+    multi = Curl::Multi.new
+    did_complete = false
+    5.times do |n|
+      # NOTE: we use google here because connecting to our TEST_URL as a local host address appears to not register correctly with lsof as a socket... if anyone knows a better way would be great to not have an external dependency here in the test
+      easy = Curl::Easy.new("http://google.com/") do |curl|
+        curl.timeout = 5 # ensure we don't hang for ever connecting to an external host
+        curl.on_complete {
+          did_complete = true
+        }
+      end
+      multi.add(easy)
+    end
+
+    multi.perform
+    assert did_complete
+    after_open = open_fds.call
+    assert_equal (after_open - before_open), 0, "auto close the connections"
+  end
+
+  def test_connection_autoclose
+    assert !Curl::Multi.autoclose
+    Curl::Multi.autoclose = true
+    assert Curl::Multi.autoclose
+  end
+
   def test_new_multi_01
     d1 = ""
     c1 = Curl::Easy.new($TEST_URL) do |curl|


### PR DESCRIPTION
Add ```Curl::Multi.autoclose``` and ```Curl::Multi#close``` to address connection leaks related to waiting for GC to run to clean up Multi handles.  If you're using Curl.get/Curl.post and generally fetching the same hosts say for an internal service etc... using the default of autoclose = false, is probably ideal because you'll keep connections alive for commonly accessed services.  If however you're making a lot of requests to many different external services you may want to run with autoclose=true.   In general, you should test which works best for your application e.g. running something like:
```netstat -anp  | grep WAIT``` on your server and ensure that it isn't growing out of control.