### PR TITLE
Documentation Tidy / Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@ ext/curb_multi.o
 ext/curb_postfield.o
 ext/curb_upload.o
 ext/curb_config.h
+
 pkg/
 ext/mkmf.log
 build/
 vendor/
 .bundle/
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 rvm:
+  - ruby-head
   - 2.6
   - 2.5
   - 2.4
   - 2.3
   - 2.2
-  - ruby-head
   - rbx-3
 matrix:
   allow_failures:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,195 +1,228 @@
 # Change Log
- ## 0.9.8
- ### Fixes
- * Fix build with curl 7.62.0
- * Support building against ruby 1.8 to help people migrate to the future and beyond
- ### Enhancements
- * Improve timeout= to allow Floating point values automatically switch to timeout_ms
- * Add SOCKS5_HOSTNAME support.
- * Addes Curl::Multi.autoclose and Curl::Multi#close to improve connection handling. In past releases connection clean up only ever happens when GC runs.  Now in this release you can explicitly control connections via multi.close or have it always close your connections with Curl::Multi.autoclose=true.
- ### Breaking Changes
- * Possibly breaking change with request handling, reduces C (lines of code) and might resolve segfault when mixing curb with ruby timeout
- * Timeout change is possibly breaking for anyone who expected 0.9 to == 0 or infinity
- ## 0.9.7
- ### Breaking Changes
- ### Fixes
- * Guard use of CURLOPT_RESOLVE in #if HAVE_CURLOPT_RESOLVE
- * Prevent `NoMethodError` when no HTTP Status
+## 0.9.8
+### Fixes
+* Fix build with curl `7.62.0`
+* Support building against Ruby `1.8` to help people migrate to the future and beyond
+### Enhancements
+* Improve `timeout=` to allow Floating point values which will automatically switch to `timeout_ms`
+* Add `SOCKS5_HOSTNAME` support
+* Added `Curl::Multi.autoclose` and `Curl::Multi#close` to improve connection handling. In past releases connection
+clean up only ever happens when GC runs. Now in this release you can explicitly control connections via
+`multi.close` or have it always close your connections with `Curl::Multi.autoclose=true`
+### Breaking Changes
+* Request handling reduces C (lines of code), and might resolve segfault when mixing curb with ruby timeout
+* Timeout change for anyone who expected `0.9` to equal `0` or `infinity`
+
+## 0.9.7
+### Breaking Changes
+### Fixes
+* Guard use of `CURLOPT_RESOLVE` in `#if HAVE_CURLOPT_RESOLVE`
+* Prevent `NoMethodError` when no HTTP Status
 * [`Curl.urlalize` will miss raw url's query params](https://github.com/taf2/curb/issues/330)
 * [Fix SSL versions constant names](https://github.com/taf2/curb/pull/333)
- ### Enhancements
- * Add `Curl::Easy#resolve` method to implement static IP overrides, bypassing DNS
+### Enhancements
+* Add `Curl::Easy#resolve` method to implement static IP overrides, bypassing DNS
 * [Add new curl features](https://github.com/taf2/curb/pull/331)
-* [Allow extending `Curl::Easy` and having a different number of constructor arguments than `Curl::Easy` allows](https://github.com/taf2/curb/pull/329)
- ## 0.9.4
- ### Fixes
- * [Fix `multi.pipeline`: `HAVE_CURLMOPT_PIPELINING` was never defined](https://github.com/taf2/curb/issues/298)
-* Eliminate warnings on Ruby 2.4.1
+* [Allow extending `Curl::Easy` and having a different number of constructor arguments
+than `Curl::Easy` allows](https://github.com/taf2/curb/pull/329)
+
+## 0.9.4
+### Fixes
+* [Fix `multi.pipeline`: `HAVE_CURLMOPT_PIPELINING` was never defined](https://github.com/taf2/curb/issues/298)
+* Eliminate warnings on Ruby `2.4.1`
 * [Hang in `select()`](https://github.com/taf2/curb/issues/323)
-* Revert 'Experimenting with adding multi handle cleanup after every request, normally would be cleaned up with GC' (problem addressed by fix hang in `select()`)
+* Revert 'Experimenting with adding multi handle cleanup after every request, normally would be cleaned up with GC
+(problem addressed by fix hang in `select()`)
 * Prevent errant callbacks once the handle is cleaned up
- ### Enhancements
- * Add `PATCH` support?
+### Enhancements
+* Add `PATCH` support?
 * Add support for `CURLOPT_PATH_AS_IS`
 * Add `.cookielist` method to `Curb::Easy`
 * Improved Windows compatibility
- ## 0.9.3
- ### Fixes
- * Correctly check for constants that may not be present in older versions of Curl
- ## 0.9.2
- ### Breaking Changes
- * Change base class for exceptions from `Exception` to `StandardError`
- ### Fixes
- * [Segmentation fault (introduced with commit 50ab567)](https://github.com/taf2/curb/issues/240)
+
+## 0.9.3
+### Fixes
+* Correctly check for constants that may not be present in older versions of Curl
+ 
+## 0.9.2
+* **Breaking change** - Change base class for exceptions from `Exception` to `StandardError`
+### Fixes
+* [Segmentation fault (introduced with commit 50ab567)](https://github.com/taf2/curb/issues/240)
 * Use 64-bit int for key in hash of active easy handles, to avoid clobbering on 32-bit systems
 * [Fix `http_auth_types` for `:any` and `:anysafe`](https://github.com/taf2/curb/issues/291)
 * [Use `LONG2NUM` and `NUM2LONG` to support all values of the `long` type](https://github.com/taf2/curb/issues/295)
 * [Support empty reason phrases in the HTTP status line](https://github.com/taf2/curb/issues/292)
- ### Enhancements
- * Implement setting of `CURLOPT_MAXCONNECTS`
+### Enhancements
+* Implement setting of `CURLOPT_MAXCONNECTS`
 * Implement setting of `CURLOPT_FORBID_REUSE`
 * Ability to specify specific allowed TLS versions when connecting
-* Add support for HTTP/2.0 and multiplexing
+* Add support for `HTTP/2.0` and multiplexing
 * Experimenting with adding multi handle cleanup after every request, normally would be cleaned up with GC
- ## 0.9.1
- ### Fixes
- * Fix regression in `timeout`/`timeout_ms` handling
- ## 0.9.0
- ### Fixes
- * Remove `CURLAUTH_ANY` as the default for authentication setting, as too many services in the world don't respond correctly with a 401 but instead 403 so the option rarely works as we'd hope
-* Use the memory address as the key to correctly keep a hash of active easy handles alive in the multi handle -- should resolve existing reports of memory leaks as well as crashes under some conditions
- ## 0.8.9
- ### Fixes
- * Only append query string if it exists
-* Setting any of CURLOPT_HEADER, CURLOPT_NOPROGRESS, CURLOPT_NOSIGNAL, CURLOPT_HTTPGET did not work (introduced in commits 4358d04 and 14e9b53)
-* Compilation for curl versions before 7.40.0
-* [`Curl::Multi.http` call of the `on_complete` callback expects unsupplied parameter](https://github.com/taf2/curb/issues/270)
- ### Enhancements
- * Add `Curl::HTTP_2_0`, and `Curl.http2?`
+
+## 0.9.1
+### Fixes
+* Fix regression in `timeout`/`timeout_ms` handling
+
+## 0.9.0
+### Fixes
+* Remove `CURLAUTH_ANY` as the default for authentication setting, as too many services in the world don't
+respond correctly with a `401` but instead `403` so the option rarely works as we'd hope
+* Use the memory address as the key to correctly keep a hash of active easy handles alive in the multi handle -- should
+resolve existing reports of memory leaks as well as crashes under some conditions
+
+## 0.8.9
+### Fixes
+* Only append query string if it exists
+* Setting any of `CURLOPT_HEADER`, `CURLOPT_NOPROGRESS`, `CURLOPT_NOSIGNAL`, `CURLOPT_HTTPGET` did not work
+(introduced in commits `4358d04` and `14e9b53`)
+* Compilation for curl versions before `7.40.0`
+* [`Curl::Multi.http` call of the `on_complete` callback expects unsupplied
+parameter](https://github.com/taf2/curb/issues/270)
+### Enhancements
+* Add `Curl::HTTP_2_0`, and `Curl.http2?`
 * Support `CURLOPT_UNIX_SOCKET_PATH` in `Curl::Easy`
 * Add `timeout_ms`/`connect_timeout_ms` options
 * Add `on_redirect` callback handling to `.http`
- ## 0.8.8
- ### Fixes
- * `Curl::Easy.http_get` [broken on macOS](https://github.com/taf2/curb/pull/242)
- ## 0.8.7
- ### Breaking Changes
- ### Fixes
- * Restore support for older, pre-7.17 versions of curl (fixes CentOS 5 compatibility)
-* Improve Ruby 2.2.x support (use `rb_thread_fd_select` instead of `rb_thread_select`)
- ### Enhancements
- * Add SOCKS4A support
+
+## 0.8.8
+### Fixes
+* [`Curl::Easy.http_get` broken on macOS](https://github.com/taf2/curb/pull/242)
+ 
+## 0.8.7
+### Breaking Changes
+### Fixes
+* Restore support for older, `pre-7.17` versions of curl (fixes CentOS 5 compatibility)
+* Improve Ruby `2.2.x` support (use `rb_thread_fd_select` instead of `rb_thread_select`)
+### Enhancements
+* Add SOCKS4A support
 * Allow custom ssl cipher lists
 * Add install instructions for Windows
 * Make it possible easily reset the Thread current handle (`Curl.reset`)
- ## 0.8.6
- ### Breaking Changes
- ### Fixes
- * Add suport for the new error `CURLM_ADDED_ALREADY` introduced at curl 7.33.0
+
+## 0.8.6
+### Breaking Changes
+### Fixes
+* Add support for the new error `CURLM_ADDED_ALREADY` introduced at curl `7.33.0`
 * Add conditionals for new `URLM_ADDED_ALREADY` error
 * `Curl#urlalize` - `CGI.escape` for param values
 * Use correct HTTP verb for DELETE requests (was `delete`, and some servers are apparently case sensitive)
 * Typo in `ext/curb_errors.c`: `BadBasswordError` -> `BadPasswordError`
 * Status method now returns the last status in the response header
- ### Enhancements
- * Support Ruby 2.2.0
+### Enhancements
+* Support Ruby `2.2.0`
 * Support `CURLOPT_TCP_NODELAY` in `Curl::Easy`
-* Raise an exception if curb doesn't know how to handle a `CURLOPT`
+* Raise an exception if `curb` doesn't know how to handle a `CURLOPT`
 * Expose license via gemspec
 * Implement seek function for multi-pass authentication uploads
- ## 0.8.5
- ### Fixes
- * Guard against a curl without GSSAPI delegation compiled in
+
+## 0.8.5
+### Fixes
+* Guard against a curl without GSSAPI delegation compiled in
 * Added `extconf.rb` entry for `appconnect`
 * Reset handle before each call when using "super simple API"
- ### Enhancements
- * Added support for `app_connect_time` from `libcurl`
+### Enhancements
+* Added support for `app_connect_time` from `libcurl`
 * Alias `body_str` to `body` and `header_str` to `head`
- ## 0.8.4
- ### Fixes
- * [Setting `post_body` to `nil` does not reset data posted in `http(:GET)`](https://github.com/taf2/curb/issues/133)
+
+## 0.8.4
+### Fixes
+* [Setting `post_body` to `nil` does not reset data posted in `http(:GET)`](https://github.com/taf2/curb/issues/133)
 * Various spurious/inconsequential warnings
 * `Curl.head` uses `OPTIONS` method instead of `HEAD` method
- ### Enhancements
- * Make "super simple API" more efficient by storing `Curl::Easy` instance in `Thread.current`
+### Enhancements
+* Make "super simple API" more efficient by storing `Curl::Easy` instance in `Thread.current`
 * GSSAPI: Add required flags for GSSAPI delegation support
 * GSSAPI: Allow setting of the new delegation flag
 * GSSAPI: Implement support for libcurl SPNEGO flags in curb
- ## 0.8.3
- ### Fixes
- * [Exception raised when process is signaled](https://github.com/taf2/curb/issues/117)
+
+## 0.8.3
+### Fixes
+* [Exception raised when process is signaled](https://github.com/taf2/curb/issues/117)
 * [Curb always appends a query to request uris](https://github.com/taf2/curb/issues/137)
- ## 0.8.2
- ### Fixes
- * Clang compatibility
- ### Enhancements
- * Allow string data with simpler interface e.g. `Curl.post('...', 'data')`
- ## 0.8.1
- ### Fixes
- * [Error installing on Ubuntu](https://github.com/taf2/curb/issues/106)
+
+## 0.8.2
+### Fixes
+* Clang compatibility
+### Enhancements
+* Allow string data with simpler interface e.g. `Curl.post('...', 'data')`
+ 
+## 0.8.1
+### Fixes
+* [Error installing on Ubuntu](https://github.com/taf2/curb/issues/106)
 * Protect callbacks from reset/close
 * `Curl::Multi` not actually performing HTTP requests in cases when the `:max_connects >= number of requests`
 * Build error when compiled with `-Werror=format-security`
 * `postalize` parameter escaping
- ### Enhancements
- * Support `CURLINFO_REDIRECT_URL`
+### Enhancements
+* Support `CURLINFO_REDIRECT_URL`
 * Support `CURLOPT_RESUME_FROM` in `Curl::Easy`
 * Add `.status` to `Curl::Easy` instances
 * Support `CURLOPT_FAILONERROR`
-* Add even easier interface: `Curl.get` / `Curl.post` / etc
- ## 0.8.0
- ### Breaking Changes
- * `on_failure` only fires for 5xx responses
- ### Fixes
- * Error in README section for HTTP POST file upload.
- ### Enhancements
- * Add a default for `resolve_mode` to `CURL_IPRESOLVE_WHATEVER` e.g. `:auto`
+* Add even easier interface: `Curl.get` / `Curl.post` / e.t.c
+
+## 0.8.0
+* **Breaking change** - `on_failure` only fires for 5xx responses 
+### Fixes
+* Error in README section for HTTP POST file upload.
+### Enhancements
+* Add a default for `resolve_mode` to `CURL_IPRESOLVE_WHATEVER` e.g. `:auto`
 * Add `on_redirect` and `on_missing` callbacks for 3xx/4xx responses
 * Allow `http_post(array_of_fields)` when using multipart form posts
- ## 0.7.18
- ### Fixes
- * Check for obsolete, since it appears to be gone from later versions of libcurl per issue #100
+
+## 0.7.18
+### Fixes
+* Check for obsolete, since it appears to be gone from later versions of libcurl per issue #100
 * Regression in PUT requests with NULL bytes (caused by `RSTRING_PTR` => `StringValueCStr` change)
- ## 0.7.17
- ### Fixes
- * Restore compatibility with 0.7.16 (e.g. suport for building without `CURLOPT_SEEKDATA`, etc)
+
+## 0.7.17
+### Fixes
+* Restore compatibility with 0.7.16 (e.g. suport for building without `CURLOPT_SEEKDATA`, etc)
 * Use `rb_thread_blocking_region` when available in place of `rb_thread_select` for ruby 1.9.x
-* Copy-paste mistake which made it impossible to set CURLOPT_SSL_VERIFYHOST to '2'
+* Copy-paste mistake which made it impossible to set `CURLOPT_SSL_VERIFYHOST` to `2`
 * Copy-paste mistake that caused `CURLOPT_SSL_VERIFYPEER` to be overwritten by the value of `use_netrc` setting
- ### Enhancements
- * Warn on exceptions in success/failure/complete callbacks
+### Enhancements
+* Warn on exceptions in success/failure/complete callbacks
 * Use `StringValueCStr` more instead of the less safe `RSTRING_PTR`
 * Defaulting `CURLOPT_SSL_VERIFYHOST` to `2` to make it consistent with cURLs default value
- ## 0.7.16
- * Add better support for timeouts issue 48
-* Improve stablity, avoid bus errors when raising in callbacks
+
+## 0.7.16
+* Add better support for timeouts - issue 48
+* Improve stability, avoid bus errors when raising in callbacks
 * Allow Content-Length header when sending a PUT request
 * Better handling of cacert
-* Support CURLOPT_IPRESOLVE
-* Allow PostField.file#to_s
-* Minor refactoring to how PostField.file handles strings
-* Accept symbol and any object that responds_to?(:to_s) for easy.http(:verb)
-* Free memory sooner after a request finishes instead of waiting for garabage collection
-* Fix crash when sending nil for the http_put body
-* Fix inspect for Curl::Easy, thanks Hongli Lai
-* Fix unit test assertions for Curl::Multi, thanks Hongli Lai
- ## 0.7.7
- * Curl::Multi perform is more robust process callbacks before exiting the loop - issue 24. thanks igrigorik and ramsingla
-* improve Curl::Multi idle callback robustness, trigger callbacks more often - issue 24. thanks igrigorik and ramsingla
- ## 0.7.6
- * fix bug in http_* when http_delete or http("verb") raises an exception
+* Support `CURLOPT_IPRESOLVE`
+* Allow `PostField.file#to_s`
+* Minor refactoring to how `PostField.file` handles strings
+* Accept symbol and any object that `responds_to?(:to_s)` for `easy.http(:verb)`
+* Free memory sooner after a request finishes instead of waiting for garbage collection
+* Fix crash when sending nil for the `http_put` body
+* Fix inspect for `Curl::Easy`, thanks Hongli Lai
+* Fix unit test assertions for `Curl::Multi`, thanks Hongli Lai
+
+## 0.7.7
+* `Curl::Multi` perform is more robust process callbacks before exiting the loop - issue 24.
+Thanks to igrigorik and ramsingla
+* improve `Curl::Multi` idle callback robustness, trigger callbacks more often - issue 24.
+Thanks to igrigorik and ramsingla
+
+## 0.7.6
+* fix bug in http_* when http_delete or http("verb") raises an exception
 * add support for autoreferrer e.g. if follow_location=true it will pass that along
- ## 0.7.5
- * minor fix for no signal instead of INT2FIX Check boolean value
- ## 0.7.4
- * add support to set the http version e.g. easy.version = Curl::HTTP_1_1
+
+## 0.7.5
+* minor fix for no signal instead of INT2FIX Check boolean value
+ 
+## 0.7.4
+* add support to set the http version e.g. `easy.version = Curl::HTTP_1_1`
 * add support to disable libcurls internal use of signals.
- ## 0.7.3
- * Support rubinius
+
+## 0.7.3
+* Support rubinius
 * allow Multi.download to be called without a block
-* add additional Multi.download examples
- ## 0.7.2
- * Start tracking high level changes
-* Add Curl::Easy#close - hard close an easy handle
-* Add Curl::Easy#reset - reset all settings but keep connections alive
+* add additional `Multi.download` examples
+
+## 0.7.2
+* Start tracking high level changes
+* Add `Curl::Easy#close` - hard close an easy handle
+* Add `Curl::Easy#reset` - reset all settings but keep connections alive
 * Maintain persistent connections for single easy handles

--- a/README.markdown
+++ b/README.markdown
@@ -16,23 +16,25 @@ Ruby license. See the LICENSE file for the gory details.
 
 ## You will need
 
-* A working Ruby installation (2.1+)
-* A working (lib)curl installation, with development stuff (7.5+, tested with 7.19.x)
+* A working Ruby installation (`1.8.7+` will work but `2.1+` preferred)
+* A working libcurl development installation
+(Ideally one of the versions listed in the compatibility chart below that maps to your `curb` version)
 * A sane build environment (e.g. gcc, make)
 
 ## Version Compatibility chart
 
-A **non-indicative** set of compatibility versions of the libcurl library with this gem is as follows
-(Note that these are only the ones that have been tested and reported to work across a variety of platforms)
+A **non-exhaustive** set of compatibility versions of the libcurl library
+with this gem are as follows. (Note that these are only the ones that have been
+tested and reported to work across a variety of platforms / rubies)
 
 | Gem Version | Release Date | libcurl versions |
 | ----------- | -----------  | ---------------- |
-| 0.9.8       | Jan 2019     | 7.61 - 7.63      |
+| 0.9.8       | Jan 2019     | 7.58 - 7.63      |
 | 0.9.7       | Nov 2018     | 7.56 - 7.60      |
-| 0.9.6       | May 2018     | 7.51 - 7.57      |
-| 0.9.5       | May 2018     | 7.51 - 7.57      |
-| 0.9.4       | Aug 2017     | 7.41 - 7.50      |
-| 0.9.3       | Apr 2016     | 7.26 - 7.43      |
+| 0.9.6       | May 2018     | 7.51 - 7.59      |
+| 0.9.5       | May 2018     | 7.51 - 7.59      |
+| 0.9.4       | Aug 2017     | 7.41 - 7.58      |
+| 0.9.3       | Apr 2016     | 7.26 - 7.58      |
 
 ## Installation...
 
@@ -45,6 +47,10 @@ the [development version of libcurl](http://curl.haxx.se/gknw.net/7.39.0/dist-w3
 line (alter paths to your curl location, but remember to use forward slashes):
 
     gem install curb --platform=ruby -- --with-curl-lib=C:/curl-7.39.0-devel-mingw32/lib --with-curl-include=C:/curl-7.39.0-devel-mingw32/include
+    
+Note that with Windows moving from one method of compiling to another as of Ruby `2.4` (DevKit -> MYSYS2),
+the usage of Ruby `2.4+` with this gem on windows is unlikely to work. It is advised to use the
+latest version of Ruby 2.3 available [HERE](https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.3.3.exe)
 
 Or, if you downloaded the archive:
 

--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Curb (probably CUrl-RuBy or something) provides Ruby-language bindings for the
 libcurl(3), a fully-featured client-side URL transfer library.
 cURL and libcurl live at [http://curl.haxx.se/](http://curl.haxx.se/) .
 
-Curb is a work-in-progress, and currently only supports libcurl's 'easy' and 'multi' modes.
+Curb is a work-in-progress, and currently only supports libcurl's `easy` and `multi` modes.
 
 ## License
 
@@ -19,6 +19,20 @@ Ruby license. See the LICENSE file for the gory details.
 * A working Ruby installation (2.1+)
 * A working (lib)curl installation, with development stuff (7.5+, tested with 7.19.x)
 * A sane build environment (e.g. gcc, make)
+
+## Version Compatibility chart
+
+A **non-indicative** set of compatibility versions of the libcurl library with this gem is as follows
+(Note that these are only the ones that have been tested and reported to work across a variety of platforms)
+
+| Gem Version | Release Date | libcurl versions |
+| ----------- | -----------  | ---------------- |
+| 0.9.8       | Jan 2019     | 7.61 - 7.63      |
+| 0.9.7       | Nov 2018     | 7.56 - 7.60      |
+| 0.9.6       | May 2018     | 7.51 - 7.57      |
+| 0.9.5       | May 2018     | 7.51 - 7.57      |
+| 0.9.4       | Aug 2017     | 7.41 - 7.50      |
+| 0.9.3       | Apr 2016     | 7.26 - 7.43      |
 
 ## Installation...
 

--- a/curb.gemspec
+++ b/curb.gemspec
@@ -7,23 +7,20 @@ Gem::Specification.new do |s|
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.markdown']
   
-  s.files = ["LICENSE", "README.markdown", "Rakefile", "doc.rb", "ext/extconf.rb", "lib/curl/easy.rb", "lib/curl/multi.rb", "lib/curb.rb", "lib/curl.rb", "ext/curb_easy.c", "ext/curb.c", "ext/curb_multi.c", "ext/curb_upload.c", "ext/curb_postfield.c", "ext/curb_errors.c", "ext/curb_postfield.h", "ext/curb_errors.h", "ext/curb_easy.h", "ext/curb_macros.h", "ext/curb.h", "ext/curb_upload.h", "ext/curb_multi.h"]
+  s.files = %w(LICENSE README.markdown Rakefile doc.rb ext/extconf.rb lib/curl/easy.rb lib/curl/multi.rb lib/curb.rb lib/curl.rb ext/curb_easy.c ext/curb.c ext/curb_multi.c ext/curb_upload.c ext/curb_postfield.c ext/curb_errors.c ext/curb_postfield.h ext/curb_errors.h ext/curb_easy.h ext/curb_macros.h ext/curb.h ext/curb_upload.h ext/curb_multi.h)
   #### Load-time details
   s.require_paths = ['lib','ext']
   s.rubyforge_project = 'curb'
   s.summary = %q{Ruby libcurl bindings}
-  s.test_files = ["tests/tc_curl_multi.rb", "tests/alltests.rb", "tests/tc_curl_easy_setopt.rb", "tests/tc_curl.rb", "tests/bug_postfields_crash.rb", "tests/bug_crash_on_progress.rb", "tests/helper.rb", "tests/bug_postfields_crash2.rb", "tests/bug_require_last_or_segfault.rb", "tests/timeout.rb", "tests/bug_crash_on_debug.rb", "tests/unittests.rb", "tests/bug_issue102.rb", "tests/bug_curb_easy_blocks_ruby_threads.rb", "tests/bug_multi_segfault.rb", "tests/bug_instance_post_differs_from_class_post.rb", "tests/require_last_or_segfault_script.rb", "tests/timeout_server.rb", "tests/tc_curl_download.rb", "tests/tc_curl_easy.rb", "tests/mem_check.rb", "tests/tc_curl_postfield.rb", "tests/bugtests.rb", "tests/tc_curl_easy_resolve.rb", "tests/signals.rb", "tests/bug_curb_easy_post_with_string_no_content_length_header.rb"]
-  
-    s.extensions << 'ext/extconf.rb'
-  
+  s.test_files = %w(tests/tc_curl_multi.rb tests/alltests.rb tests/tc_curl_easy_setopt.rb tests/tc_curl.rb tests/bug_postfields_crash.rb tests/bug_crash_on_progress.rb tests/helper.rb tests/bug_postfields_crash2.rb tests/bug_require_last_or_segfault.rb tests/timeout.rb tests/bug_crash_on_debug.rb tests/unittests.rb tests/bug_issue102.rb tests/bug_curb_easy_blocks_ruby_threads.rb tests/bug_multi_segfault.rb tests/bug_instance_post_differs_from_class_post.rb tests/require_last_or_segfault_script.rb tests/timeout_server.rb tests/tc_curl_download.rb tests/tc_curl_easy.rb tests/mem_check.rb tests/tc_curl_postfield.rb tests/bugtests.rb tests/tc_curl_easy_resolve.rb tests/signals.rb tests/bug_curb_easy_post_with_string_no_content_length_header.rb)
+  s.extensions << 'ext/extconf.rb'
 
   #### Documentation and testing.
   s.has_rdoc = true
   s.homepage = 'http://curb.rubyforge.org/'
   s.rdoc_options = ['--main', 'README.markdown']
 
-  
-    s.platform = Gem::Platform::RUBY
+  s.platform = Gem::Platform::RUBY
   
   s.licenses = ['Ruby']
 end

--- a/lib/curb.gemspec.erb
+++ b/lib/curb.gemspec.erb
@@ -7,14 +7,18 @@ Gem::Specification.new do |s|
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.markdown']
   <%
-    files = ['LICENSE', 'README.markdown', 'Rakefile',
-             'doc.rb', 'ext/extconf.rb'] + Dir["lib/**/**.rb"] + Dir["ext/**/**.c"] + Dir["ext/**/**.h"].reject{|h| h == 'ext/curb_config.h' }
+    files = %w(LICENSE README.markdown Rakefile doc.rb ext/extconf.rb) +
+      Dir["lib/**/**.rb"] +
+      Dir["ext/**/**.c"] +
+      Dir["ext/**/**.h"].
+      reject{|h| h == 'ext/curb_config.h' }
 
     if ENV['BINARY_PACKAGE']
       files += Dir['ext/**/*.{o,so,bundle}']
     end
   %>
   s.files = <%= files.inspect %>
+
   #### Load-time details
   s.require_paths = ['lib','ext']
   s.rubyforge_project = 'curb'


### PR DESCRIPTION
I'm using this gem a lot. So figured I'd try and contribute to a bit of tidy-up before I look to contribute to anything else.

I've cleaned up the changelog, fixed some typos and amended some inconsistent formatting
I've done a bit of feng shui and some quick-win rubocop tidies, to try improve legibility
I've added a *very conservative* gem compatibility chart with the `libcurl` library. I've added in the SHA for the compatibility chart that this is a safety-first approach, so the versions in there will work, but others probably will too!