### PR TITLE
add support for `CURLOPT_STDERR`

### DIFF
--- a/ext/curb.h
+++ b/ext/curb.h
@@ -9,6 +9,13 @@
 #define __CURB_H
 
 #include <ruby.h>
+
+#ifdef HAVE_RUBY_IO_H
+#include "ruby/io.h"
+#else
+#include "rubyio.h" // ruby 1.8
+#endif
+
 #include <curl/curl.h>
 
 #include "curb_config.h"

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -422,6 +422,8 @@ test_for("curl_easy_escape", "CURL_EASY_ESCAPE", %{
 
 have_func('rb_thread_blocking_region')
 have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
+have_header('ruby/io.h')
+have_func('rb_io_stdio_file')
 
 create_header('curb_config.h')
 create_makefile('curb_core')

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -2,6 +2,7 @@
 # Copyright (c)2006 Ross Bamford. See LICENSE.
 $CURB_TESTING = true
 require 'uri'
+require 'stringio'
 
 $TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 $EXTDIR = File.join($TOPDIR, 'ext')


### PR DESCRIPTION
This allows to capture verbose output without hijacking global `STDERR`.
`libcurl` requires a raw `FILE` pointer so it works only with IO objects
in Ruby. String or StringIO won't do.

This is as simple as I could make it and it will either work or explode
with a meaningful exception ("wrong argument type Tempfile (expected File)").

Tested on rubies 1.8 up to 2.6.

Fixes https://github.com/taf2/curb/issues/378