### PR TITLE
Show error details from CURLOPT_ERRORBUFFER in exception messages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.8)
+    curb (0.9.10)
 
 GEM
   remote: https://rubygems.org/

--- a/ext/curb_easy.h
+++ b/ext/curb_easy.h
@@ -36,6 +36,9 @@ typedef struct {
   /* The handler */
   CURL *curl;
 
+  /* Buffer for error details from CURLOPT_ERRORBUFFER */
+  char err_buf[CURL_ERROR_SIZE];
+
   VALUE opts; /* rather then allocate everything we might need to store, allocate a Hash and only store objects we actually use... */
   VALUE multi; /* keep a multi handle alive for each easy handle not being used by a multi handle.  This improves easy performance when not within a multi context */
 

--- a/lib/curl/easy.rb
+++ b/lib/curl/easy.rb
@@ -75,8 +75,9 @@ module Curl
       end
 
       if self.last_result != 0 && self.on_failure.nil?
-        error = Curl::Easy.error(self.last_result)
-        raise error.first.new(self.head)
+        (err_class, err_summary) = Curl::Easy.error(self.last_result)
+        err_detail = self.last_error
+        raise err_class.new([err_summary, err_detail].compact.join(": "))
       end
 
       ret


### PR DESCRIPTION
Currently in curb, exceptions due to network errors during requests don't have a general description of the problem, just the raw text of the response header if it could be retrieved. I have a hard time debugging problems with only that. Also, response headers can be much longer than exception messages usually are, which can cause weirdness in logs and monitoring systems.

In this PR, the exception message is instead based on (a) the error code summary that we already get from `rb_curl_easy_error` and (b) error details from [`CURLOPT_ERRORBUFFER`](https://curl.haxx.se/libcurl/c/CURLOPT_ERRORBUFFER.html). The error buffer is cleared out before each request, so that we don't show outdated information in versions of Curl before 7.60.0 (which don't clear out the buffer for you).

When needed, the user can still debug the response header with `verbose` or `on_debug`.