### PR TITLE
Update tc_curl_easy.rb

### DIFF
--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -21,7 +21,7 @@ class TestCurbCurlEasy < Test::Unit::TestCase
     end
     output = File.read(path)
 
-    assert_match('HTTP/1.1 200 OK ', output)
+    assert_match('HTTP/1.1 200 OK', output)
     assert_match('Host: 127.0.0.1:9129', output)
   end
 


### PR DESCRIPTION
fix this spec that broken in ruby 2.7
Reference: https://people.debian.org/~kanashiro/ruby2.7/builds/0/ruby-curb/ruby-curb_0.9.10-1+rebuild1578358831_amd64-2020-01-07T01:00:32Z.build.txt