### PR TITLE
CI: Drop rbx-3, unsupported by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ rvm:
   - 2.3
   - 2.2
 matrix:
+  include:
+    name: Rubinius
+    rvm: rbx-3
+    dist: trusty
   fast_finish: true
 cache: bundler
 before_install:
-  - gem update bundler
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ rvm:
   - 2.4
   - 2.3
   - 2.2
-  - rbx-3
 matrix:
-  allow_failures:
-   - rvm: rbx-3
   fast_finish: true
 cache: bundler
 before_install:


### PR DESCRIPTION
It used to be that rbx, then rbx-3 were installable `rvm` monikers in Travis.

No longer.

The rbx-3.107 is the newest one which can be found (and only supported-ish on 1 `dist` setting).

The latest 4.x Rubinius is not provided by Travis.