### PR TITLE
fix enabling haproxy protocol

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3596,7 +3596,7 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
 #endif
 #if HAVE_CURLOPT_HAPROXYPROTOCOL
   case CURLOPT_HAPROXYPROTOCOL:
-    curl_easy_setopt(rbce->curl, HAVE_CURLOPT_HAPROXYPROTOCOL, NUM2LONG(val));
+    curl_easy_setopt(rbce->curl, CURLOPT_HAPROXYPROTOCOL, NUM2LONG(val));
     break;
 #endif
   case CURLOPT_STDERR:


### PR DESCRIPTION
The following code does not have the intended behavior

  curl.setopt(Curl::CURLOPT_HAPROXYPROTOCOL, 1)

The expected header does not get set. This looks like a small typo.

Instead of passing the truthy HAVE_CURLOPT_HAPROXYPROTOCOL we should
be passing CURLOPT_HAPROXYPROTOCOL to curl_easy_setopt.

Validated by rebuilding the gem with the changes and re-testing.