### PR TITLE
Build fix: Gemfile.lock: update gems to avoid changes in lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    curb (0.9.10)
+    curb (0.9.11)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This PR is an attempt to avoid the following build error in: https://travis-ci.org/github/taf2/curb/jobs/741142541

```
$ bundle install --jobs=3 --retry=3 --deployment --path=${BUNDLE_PATH:-vendor/bundle}

You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
The gemspecs for path gems changed
```

## Result

It avoids the error  and continues!

This takes us to the _next build error_ - which is a good thing.

## Details

https://github.com/taf2/curb/compare/fa6e08ecb878...fc43c798332b introduced a .11 but the Gemfile.lock wasn't informed.