### PR TITLE
docs: fix simple typo, pippelining -> pipelining

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -2955,7 +2955,7 @@ static VALUE ruby_curl_easy_connect_time_get(VALUE self) {
  * Retrieve the time, in seconds, it took from the start until the SSL/SSH
  * connect/handshake to the remote host was completed. This time is most often
  * very near to the pre transfer time, except for cases such as HTTP
- * pippelining where the pretransfer time can be delayed due to waits in line
+ * pipelining where the pretransfer time can be delayed due to waits in line
  * for the pipeline and more.
  */
 #if defined(HAVE_CURLINFO_APPCONNECT_TIME)


### PR DESCRIPTION
There is a small typo in ext/curb_easy.c.

Should read `pipelining` rather than `pippelining`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md