### PR TITLE
Add CURLOPT_SSL_SESSIONID_CACHE option into setopt

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -3606,6 +3606,11 @@ static VALUE ruby_curl_easy_set_opt(VALUE self, VALUE opt, VALUE val) {
     GetOpenFile(val, open_f_ptr);
     curl_easy_setopt(rbce->curl, CURLOPT_STDERR, rb_io_stdio_file(open_f_ptr));
     break;
+#if HAVE_CURLOPT_SSL_SESSIONID_CACHE
+  case CURLOPT_SSL_SESSIONID_CACHE:
+    curl_easy_setopt(rbce->curl, CURLOPT_SSL_SESSIONID_CACHE, NUM2LONG(val));
+    break;
+#endif
   default:
     rb_raise(rb_eTypeError, "Curb unsupported option");
   }


### PR DESCRIPTION
Add Curl::CURLOPT_SSL_SESSIONID_CACHE constant support into setopt method. [See more about this parameter](https://curl.se/libcurl/c/CURLOPT_SSL_SESSIONID_CACHE.html)