### PR TITLE
Call curl_global_cleanup at exit

### DIFF
--- a/ext/curb.c
+++ b/ext/curb.c
@@ -235,12 +235,16 @@ static VALUE ruby_curl_http2_q(VALUE mod) {
 #endif
 }
 
+static void finalize_curb_core(VALUE data) {
+  curl_global_cleanup();
+}
+
 void Init_curb_core() {
-  // TODO we need to call curl_global_cleanup at exit!
   curl_version_info_data *ver;
   VALUE curlver, curllongver, curlvernum;
 
   curl_global_init(CURL_GLOBAL_ALL);
+  rb_set_end_proc(finalize_curb_core, Qnil);
   ver = curl_version_info(CURLVERSION_NOW);
 
   mCurl = rb_define_module("Curl");


### PR DESCRIPTION
https://github.com/ruby/ruby/blob/v3_1_1/include/ruby/internal/intern/eval.h#L210-L218

```c
/**
 * Registers a function  that shall run on process  exit.  Registered functions
 * run in  reverse-chronological order,  mixed with  syntactic `END`  block and
 * `Kernel#at_exit`.
 *
 * @param[in]  func  Function to run at process exit.
 * @param[in]  arg   Passed as-is to `func`.
 */
void rb_set_end_proc(void (*func)(VALUE arg), VALUE arg);
```