### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - '2.2'
@@ -19,6 +20,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
           - head
     name: Ruby ${{ matrix.ruby }}
     continue-on-error: ${{ matrix.ruby == 'head' }}
@@ -26,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: apt-get install
         run: |
-          sudo apt-get install libcurl4 libcurl3-gnutls libcurl4-openssl-dev -y
+          sudo apt-get update && sudo apt-get install libcurl4 libcurl3-gnutls libcurl4-openssl-dev -y
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,10 @@ gemspec
 
 gem 'mixlib-shellout'
 gem 'pry'
-gem 'webrick'
 
 group 'development', 'test' do
   gem 'webrick' # for ruby 3.1
-  gem 'rdoc', ">= 6.3.1"
+  gem 'rdoc'
   gem 'rake', '>= 13.0.1'
   gem 'test-unit'
 end


### PR DESCRIPTION
* Add Ruby 3.1
* Disable fail-fast so the full matrix always runs
* Run `apt-get update` before `apt-get install`
* Relax `rdoc` version constraint to keep older Rubies working
* Remove duplicate `webrick` entry