### PR TITLE
Use `Ruby` license in curb.gemspec.erb

### DIFF
--- a/lib/curb.gemspec.erb
+++ b/lib/curb.gemspec.erb
@@ -36,5 +36,5 @@ Gem::Specification.new do |s|
   <% else %>
   s.platform = Gem::Platform::RUBY
   <% end %>
-  s.licenses = ['MIT']
+  s.licenses = ['Ruby']
 end


### PR DESCRIPTION
The project is has Ruby license, however, the MIT keeps popping up due to this template. So fix the license in template to fix it once and for all.

This should help to address #436, which seems to be the most recent reincarnation of the issue