### PR TITLE
Remove unused `cgi` require

### DIFF
--- a/lib/curl.rb
+++ b/lib/curl.rb
@@ -3,7 +3,6 @@ require 'curb_core'
 require 'curl/easy'
 require 'curl/multi'
 require 'uri'
-require 'cgi'
 
 # expose shortcut methods
 module Curl


### PR DESCRIPTION
It's usage was removed in https://github.com/taf2/curb/commit/32fa6d78968c3b63e2a54a2c326efb577db04043

Requiring `cgi` like this will emit a warning on Ruby 3.5: https://bugs.ruby-lang.org/issues/21258