### PR TITLE
Skip NTLM assertion in test_username_password when libcurl lacks NTLM

### DIFF
--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -1560,6 +1560,10 @@ class TestCurbCurlEasy < Test::Unit::TestCase
       # header value and encoding; skip the NTLM-specific assertion.
       return
     end
+    # curl 8.20.0 disables NTLM by default and plans to remove it in
+    # September 2026; libcurl silently downgrades to Basic when NTLM is
+    # unavailable, so skip the NTLM-specific assertion in that case.
+    return unless Curl.ntlm?
     curl = Curl::Easy.new(TestServlet.url)
     curl.username = "foo"
     curl.password = "bar"


### PR DESCRIPTION
 curl 8.20.0 disables NTLM support by default (with planned removal in
 September 2026). When NTLM is unavailable, libcurl silently downgrades
 to Basic auth, breaking the assertion that expects an NTLM Type 1
 message. Use Curl.ntlm? to skip the NTLM-specific portion of the test
 when libcurl was built without NTLM support.

 Closes: https://github.com/taf2/curb/issues/474