### PR TITLE
Disable proxy in CURLOPT_RESOLVE tests

### DIFF
--- a/tests/tc_curl_easy.rb
+++ b/tests/tc_curl_easy.rb
@@ -46,6 +46,7 @@ class TestCurbCurlEasy < Test::Unit::TestCase
 
     http = Curl::Easy.new(url)
     http.dns_cache_timeout = 0
+    http.proxy_url = ""
     http.resolve = [mapping]
     http.get
     assert_match(/GET/, http.body)

--- a/tests/tc_curl_easy_resolve.rb
+++ b/tests/tc_curl_easy_resolve.rb
@@ -22,6 +22,7 @@ class TestCurbCurlEasyResolve < Test::Unit::TestCase
     mapping = "#{host}:#{TestServlet.port}:127.0.0.1"
 
     @easy.url = "http://#{host}:#{TestServlet.port}#{TestServlet.path}"
+    @easy.proxy_url = ""
     @easy.dns_cache_timeout = 0
     @easy.set(:resolve, [mapping])
 
@@ -39,6 +40,7 @@ class TestCurbCurlEasyResolve < Test::Unit::TestCase
     entry.define_singleton_method(:to_s) { mapping }
 
     @easy.url = "http://#{host}:#{TestServlet.port}#{TestServlet.path}"
+    @easy.proxy_url = ""
     @easy.dns_cache_timeout = 0
     @easy.resolve = [entry]
 

--- a/tests/tc_curl_native_coverage.rb
+++ b/tests/tc_curl_native_coverage.rb
@@ -70,6 +70,7 @@ class TestCurbCurlNativeCoverage < Test::Unit::TestCase
 
   def test_clone_preserves_native_lists_after_original_handle_closes
     easy = Curl::Easy.new("http://curb.invalid:#{TestServlet.port}#{TestServlet.path}")
+    easy.proxy_url = ""
     easy.headers['X-Test'] = '1'
     easy.proxy_headers['X-Proxy'] = '2'
     easy.ftp_commands = ['PWD']


### PR DESCRIPTION
The resolve tests map a bogus hostname (curb.invalid) to 127.0.0.1 via CURLOPT_RESOLVE and expect curl to reach the local WEBrick test server. When http_proxy is set, libcurl forwards the request to the proxy and ignores the CURLOPT_RESOLVE mapping. The proxy cannot resolve curb.invalid and returns an error page, so the assertions fail.

Unset the proxy on the handles these tests use, so curl performs its own resolution and connects directly to the loopback server.

---

We [started hitting errors](https://autopkgtest.ubuntu.com/results/autopkgtest-stonking/stonking/amd64/r/ruby-curb/20260612_093431_27e7a@/log.gz) when running tests for curb in Ubuntu after enabling a proxy (via the `http_proxy` environment variable).

This can be reproduced locally by running a proxy that rewrites error pages, such as tinyproxy. I used this configuration:

```
Port 9001
Listen 127.0.0.1
Allow 127.0.0.1
```

And setting the `http_proxy` environment variable to `127.0.0.1:9001`.