### PR TITLE
pin rbce->self against GC compaction

### DIFF
--- a/ext/curb_easy.c
+++ b/ext/curb_easy.c
@@ -1187,6 +1187,7 @@ static int proc_debug_handler(CURL *curl,
 static void curl_easy_mark(void *ptr) {
   ruby_curl_easy *rbce = (ruby_curl_easy *)ptr;
   if (rbce) {
+    if (!NIL_P(rbce->self)) { rb_gc_mark(rbce->self); }
     if (!NIL_P(rbce->opts)) { rb_gc_mark(rbce->opts); }
     if (!NIL_P(rbce->multi)) { rb_gc_mark(rbce->multi); }
     if (!NIL_P(rbce->callback_error)) { rb_gc_mark(rbce->callback_error); }

--- a/tests/tc_gc_compact.rb
+++ b/tests/tc_gc_compact.rb
@@ -96,6 +96,52 @@ class TestGcCompact < Test::Unit::TestCase
     end
   end
 
+  # Regression: after compaction relocates a persistent Curl::Easy and its old
+  # heap slot is recycled by another T_DATA object, completion dispatch (which
+  # reads the rbce->self back-reference via CURLINFO_PRIVATE) must still
+  # resolve to the correct Curl::Easy. Without pinning in curl_easy_mark this
+  # raises "TypeError: wrong argument type Curl::Upload (expected Curl::Easy)"
+  # on the first round, or defers it onto the multi and raises it from a later
+  # request.
+  def test_completion_dispatch_survives_compact_and_slot_reuse
+    omit('needs GC.verify_compaction_references') unless GC.respond_to?(:verify_compaction_references)
+
+    # Heap-only reference: holding the easy in a local would pin it to the
+    # stack and mask the bug.
+    holder = { easy: Curl::Easy.new($TEST_URL) }
+    holder[:easy].timeout = 5
+    completed = nil
+    holder[:easy].on_complete { |e| completed = e }
+    holder[:easy].http(:GET)
+    assert_same holder[:easy], completed
+    expected_body = holder[:easy].body_str
+    refute_empty expected_body
+
+    3.times do
+      # Relocate every movable object, then recycle freed slots with other
+      # T_DATA instances so a stale back-reference cannot fail soft.
+      GC.verify_compaction_references(toward: :empty, expand_heap: true)
+      churn = Array.new(50_000) { Curl::Upload.new }
+
+      completed = nil
+      holder[:easy].http(:GET)
+
+      multi = holder[:easy].multi
+      if multi&.instance_variable_defined?(:@__curb_deferred_exception)
+        raise multi.instance_variable_get(:@__curb_deferred_exception)
+      end
+      assert_same holder[:easy], completed
+      assert_equal expected_body, holder[:easy].body_str
+      churn.clear
+    end
+  ensure
+    begin
+      holder[:easy]&.close
+    rescue StandardError
+      nil
+    end
+  end
+
   private
 
   def run_multi_perform_compact_iteration


### PR DESCRIPTION
## Summary

We've hit the following issue and I prepared an AI assisted report for maximum details.

`Curl::Easy` does not survive GC compaction: the `rbce->self` back-reference is a
raw VALUE in the malloc'd `ruby_curl_easy` struct, `curl_easy_mark` never marks it,
and the data type has no `dcompact` handler — so the wrapper object is movable and
any compaction (`GC.compact`, `GC.auto_compact`, `Process.warmup`) leaves
`rbce->self` pointing at the old heap slot. This PR pins the wrapper by marking
`rbce->self` in `curl_easy_mark`, the same way the mark function already handles
`opts`/`multi`/`callback_error`.

## Failure mode

On every completed transfer, `find_easy_value_for_handle()` (curb_multi.c) reads
the struct back through `CURLINFO_PRIVATE` and trusts `rbce->self`. Its
`RB_TYPE_P(easy, T_DATA)` guard only helps while the Easy's old slot is empty; once
the freed slot is recycled by **any other T_DATA object**, the guard passes and the
completion path operates on the wrong object:

```
TypeError: wrong argument type Curl::Upload (expected Curl::Easy)
```

What makes this nasty to diagnose in production is *where* it raises: inside the
`rb_protect` in `rb_curl_multi_read_info()`. The exception is stashed as the
multi's deferred exception, attributed to the resurrected wrong object. The
corrupted request itself **appears to succeed** (response code and body are already
populated), its completion bookkeeping (`curl_multi_remove_handle`, active count,
attached table) is skipped, and the TypeError surfaces on a later, unrelated
request. We chased sporadic, seemingly random `TypeError` /
`Curl::Err::CurlError "Unknown error result from libcurl"` failures in production
(persistent keep-alive handles via elastic-transport's Curb adapter, in a process
that calls `Process.warmup` at boot) for a while before isolating this.

## Reproduction

Deterministic against vanilla 1.3.6 (observed on ruby 4.0, linux). Ingredients:
a persistent Easy held only via a heap reference (a local variable would pin it to
the stack and mask the bug), one forced compaction, and a burst of T_DATA
allocations to recycle the freed slot.

```ruby
require 'curb'
require 'socket'

server = TCPServer.new('127.0.0.1', 0)
port = server.addr[1]
Thread.new do
  loop do
    c = server.accept
    Thread.new(c) do |s|
      while (line = s.gets)
        next unless line == "\r\n"
        s.write "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok"
      end
    rescue IOError, Errno::EPIPE, Errno::ECONNRESET
    end
  end
end

H = { easy: Curl::Easy.new("http://127.0.0.1:#{port}/") }
H[:easy].http(:GET)

50.times do |r|
  # 1. relocate the Easy (rbce->self goes stale)
  GC.verify_compaction_references(toward: :empty, expand_heap: true)
  # 2. recycle its freed slot with other T_DATA objects
  churn = Array.new(50_000) { Curl::Upload.new }
  # 3. the next completion resurrects the wrong object
  H[:easy].http(:GET)

  multi = H[:easy].multi
  if multi&.instance_variable_defined?(:@__curb_deferred_exception)
    e = multi.instance_variable_get(:@__curb_deferred_exception)
    abort "CORRUPTED at round #{r}: #{e.class}: #{e.message}"
  end
  puts "round #{r + 1} ok"
end
puts 'survived'
```

Results:

- **Unpatched**: aborts at round 0, 3/3 trials, with the TypeError above. (Dropping
  the deferred-exception check and just looping raises the same TypeError from a
  subsequent request instead — the misattribution described above.)
- **Patched**: survives 200 rounds, 2/2 trials. Also survived a soak of our
  production-shaped harness: 1M requests on a persistent handle with ~100 forced
  full-heap compactions, versus corruption within ~40k–110k requests unpatched
  under natural GC timing.

Since pinning makes the Easy immovable, the stale-self window is closed by
construction, not by timing.

The PR includes a regression test in `tests/tc_gc_compact.rb`
(`test_completion_dispatch_survives_compact_and_slot_reuse`) exercising this
path against the tests' `$TEST_URL`: it errors with the TypeError above on the
unpatched build and passes with the fix. It omits itself on Rubies without
`GC.verify_compaction_references`.

## Alternative considered

The fix keeps the existing `rb_gc_mark` style, at the cost of making live Easy
objects unmovable — which seemed acceptable for the handful of handles a process
realistically holds. The movability-preserving alternative would be
`rb_gc_mark_movable` plus a `dcompact` handler updating `rbce->self` via
`rb_gc_location()`, but that also requires auditing the other raw VALUEs curb
keeps in C-owned memory (e.g. the multi's `attached` st_table values, which a
mid-transfer compaction could leave stale in the same way). Happy to rework in
that direction if you'd rather keep the object movable.
